### PR TITLE
refactor(hire_purchase): rename dashboard endpoint to stats

### DIFF
--- a/apps/hire_purchase/api/views.py
+++ b/apps/hire_purchase/api/views.py
@@ -114,8 +114,8 @@ class HirePurchaseRegistrationViewSet(viewsets.ModelViewSet):
         serializer.save()
         return Response(serializer.data, status=status.HTTP_200_OK)
 
-    @action(detail=False, methods=["get"], url_path="dashboard")
-    def dashboard(self, request: Request) -> Response:
+    @action(detail=False, methods=["get"], url_path="stats")
+    def stats(self, request: Request) -> Response:
         """
         Returns the three headline statistics shown at the top of the HP
         """


### PR DESCRIPTION
Update the url_path and method name from 'dashboard' to 'stats' to better reflect the purpose of returning headline statistics.