### PR TITLE
feat(frontend): implement discharge and closure workflows

### DIFF
--- a/frontend/src/api/collateralApi.ts
+++ b/frontend/src/api/collateralApi.ts
@@ -54,7 +54,11 @@ function mapCollateralRecord(
       (record.financier_type as CollateralRecord['financier_type']) ?? 'company',
     financier_id: Number(record.financier ?? record.financier_id ?? 0),
     data_date: String(record.data_date ?? record.lodge_date ?? ''),
-    status: record.is_discharged ? 'discharged' : 'active',
+    status: record.is_discharged
+      ? 'discharged'
+      : record.is_pending_discharge
+        ? 'pending_discharge'
+        : 'active',
   };
 }
 
@@ -110,7 +114,9 @@ export const collateralApi = {
   },
 
   dischargeRecord: async (id: number): Promise<CollateralRecord> => {
-    const { data } = await axiosInstance.post(`/collateral/${id}/discharge/`);
+    const { data } = await axiosInstance.patch(`/collateral/${id}/discharge/`, {
+      is_discharged: true,
+    });
     return mapCollateralRecord(unwrapApiData<Record<string, unknown>>(data));
   },
 };

--- a/frontend/src/api/hirePurchaseApi.ts
+++ b/frontend/src/api/hirePurchaseApi.ts
@@ -77,7 +77,11 @@ export const hirePurchaseApi = {
             record.financier_display ?? record.financier_name ?? '',
           financier_id: record.financier ?? record.financier_id ?? 0,
           data_date: record.data_date ?? record.lodge_date ?? '',
-          status: (record.closure_confirmed ? 'closed' : 'active') as HirePurchaseRecord['status'],
+          status: (record.closure_confirmed
+            ? 'closed'
+            : record.is_pending_closure
+              ? 'pending_closure'
+              : 'active') as HirePurchaseRecord['status'],
         }))
       : [];
 
@@ -117,10 +121,19 @@ export const hirePurchaseApi = {
   },
 
   confirmClosure: async (id: number): Promise<HirePurchaseRecord> => {
-    const { data } = await axiosInstance.post<ApiResponse<HirePurchaseRecord>>(
+    const { data } = await axiosInstance.patch<ApiResponse<HirePurchaseRecord>>(
       `/hire-purchase/${id}/confirm-closure/`,
+      { closure_confirmed: true },
     );
-    return data.data ?? (data as unknown as HirePurchaseRecord);
+    const raw = (data.data ?? data) as unknown as Record<string, unknown>;
+    return {
+      ...(data.data ?? (data as unknown as HirePurchaseRecord)),
+      status: (raw.closure_confirmed
+        ? 'closed'
+        : raw.is_pending_closure
+          ? 'pending_closure'
+          : 'active') as HirePurchaseRecord['status'],
+    };
   },
 
   getFinanciers: async (): Promise<User[]> => {

--- a/frontend/src/components/collateral/CollateralViewModal.tsx
+++ b/frontend/src/components/collateral/CollateralViewModal.tsx
@@ -1,12 +1,13 @@
 import { useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
 import { Modal } from '@/components/shared/Modal';
 import { CollateralForm } from './CollateralForm';
 import type { CollateralRecord } from '@/types';
 import { formatCurrency, formatDate } from '@/lib/utils';
 import { assetTypeLabel } from '@/lib/assetTypes';
 import { Button } from '@/components/ui/button';
-import { Edit } from 'lucide-react';
+import { Edit, CheckCircle } from 'lucide-react';
 import { DeleteRecordButton } from '@/components/shared/DeleteRecordButton';
 import { collateralApi } from '@/api/collateralApi';
 
@@ -24,11 +25,31 @@ export function CollateralViewModal({
   onDeleted,
 }: CollateralViewModalProps) {
   const [editMode, setEditMode] = useState(false);
+  const [confirmingDischarge, setConfirmingDischarge] = useState(false);
+  const queryClient = useQueryClient();
 
   const { data: detail } = useQuery({
     queryKey: ['collateral-detail', record.id],
     queryFn: () => collateralApi.getRecord(record.id),
     staleTime: 5 * 60 * 1000,
+  });
+
+  const currentStatus = detail?.status ?? record.status;
+
+  const { mutate: discharge, isPending: isDischarging } = useMutation({
+    mutationFn: () => collateralApi.dischargeRecord(record.id),
+    onSuccess: () => {
+      toast.success('Collateral discharged successfully');
+      queryClient.invalidateQueries({ queryKey: ['collateral-detail', record.id] });
+      queryClient.invalidateQueries({ queryKey: ['collateral-dashboard'] });
+      queryClient.invalidateQueries({ queryKey: ['collateral'] });
+      setConfirmingDischarge(false);
+      onSaved();
+    },
+    onError: (err: any) => {
+      toast.error(err?.response?.data?.message ?? 'Failed to discharge record');
+      setConfirmingDischarge(false);
+    },
   });
 
   return (
@@ -113,7 +134,41 @@ export function CollateralViewModal({
               onDelete={() => collateralApi.deleteRecord(record.id)}
               onDeleted={onDeleted}
             />
-            <div className="flex gap-2">
+            <div className="flex gap-2 items-center">
+              {currentStatus !== 'discharged' && (
+                confirmingDischarge ? (
+                  <>
+                    <span className="text-xs text-amber-700">Confirm discharge?</span>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="primary"
+                      loading={isDischarging}
+                      onClick={() => discharge()}
+                    >
+                      Yes, Discharge
+                    </Button>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="ghost"
+                      onClick={() => setConfirmingDischarge(false)}
+                    >
+                      Cancel
+                    </Button>
+                  </>
+                ) : (
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="secondary"
+                    leftIcon={<CheckCircle className="h-3.5 w-3.5" />}
+                    onClick={() => setConfirmingDischarge(true)}
+                  >
+                    Discharge
+                  </Button>
+                )
+              )}
               <Button variant="ghost" onClick={onClose}>
                 Close
               </Button>

--- a/frontend/src/components/hire-purchase/HirePurchaseViewModal.tsx
+++ b/frontend/src/components/hire-purchase/HirePurchaseViewModal.tsx
@@ -1,10 +1,12 @@
 import { useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
 import { Modal } from '@/components/shared/Modal';
 import { HirePurchaseForm } from './HirePurchaseForm';
 import type { HirePurchaseRecord } from '@/types';
 import { formatCurrency, formatDate } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
-import { Edit } from 'lucide-react';
+import { Edit, CheckCircle } from 'lucide-react';
 import { DeleteRecordButton } from '@/components/shared/DeleteRecordButton';
 import { hirePurchaseApi } from '@/api/hirePurchaseApi';
 
@@ -22,6 +24,23 @@ export function HirePurchaseViewModal({
   onDeleted,
 }: HirePurchaseViewModalProps) {
   const [editMode, setEditMode] = useState(false);
+  const [confirmingClosure, setConfirmingClosure] = useState(false);
+  const queryClient = useQueryClient();
+
+  const { mutate: confirmClosure, isPending: isConfirming } = useMutation({
+    mutationFn: () => hirePurchaseApi.confirmClosure(record.id),
+    onSuccess: () => {
+      toast.success('Hire purchase closure confirmed');
+      queryClient.invalidateQueries({ queryKey: ['hire-purchase-dashboard'] });
+      queryClient.invalidateQueries({ queryKey: ['hire-purchase'] });
+      setConfirmingClosure(false);
+      onSaved();
+    },
+    onError: (err: any) => {
+      toast.error(err?.response?.data?.message ?? 'Failed to confirm closure');
+      setConfirmingClosure(false);
+    },
+  });
 
   return (
     <Modal
@@ -78,6 +97,7 @@ export function HirePurchaseViewModal({
               ['Balance', formatCurrency(record.balance)],
               ['Start Date', formatDate(record.start_date)],
               ['End Date', formatDate(record.end_date)],
+              ['Status', record.status],
             ].map(([k, v]) => (
               <div key={String(k)}>
                 <dt className="text-xs font-medium uppercase text-slate-400">
@@ -94,7 +114,41 @@ export function HirePurchaseViewModal({
               onDelete={() => hirePurchaseApi.deleteRecord(record.id)}
               onDeleted={onDeleted}
             />
-            <div className="flex gap-2">
+            <div className="flex gap-2 items-center">
+              {record.status !== 'closed' && (
+                confirmingClosure ? (
+                  <>
+                    <span className="text-xs text-amber-700">Confirm closure?</span>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="primary"
+                      loading={isConfirming}
+                      onClick={() => confirmClosure()}
+                    >
+                      Yes, Confirm
+                    </Button>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="ghost"
+                      onClick={() => setConfirmingClosure(false)}
+                    >
+                      Cancel
+                    </Button>
+                  </>
+                ) : (
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="secondary"
+                    leftIcon={<CheckCircle className="h-3.5 w-3.5" />}
+                    onClick={() => setConfirmingClosure(true)}
+                  >
+                    Confirm Closure
+                  </Button>
+                )
+              )}
               <Button variant="ghost" onClick={onClose}>
                 Close
               </Button>

--- a/frontend/src/pages/AssetRegistryPage.tsx
+++ b/frontend/src/pages/AssetRegistryPage.tsx
@@ -212,6 +212,7 @@ export default function AssetRegistryPage() {
             <table className="w-full border-collapse text-[13px]">
               <thead>
                 <tr className="sticky top-0 z-10 border-b border-[#8f8f8f] bg-white text-left divide-x divide-[#8f8f8f]">
+                  <th className="w-8 px-2 py-2 font-bold text-black">#</th>
                   <th className="px-2 py-2 font-bold text-black">
                     <button
                       type="button"
@@ -261,12 +262,13 @@ export default function AssetRegistryPage() {
                   </th>
                   <th className="px-2 py-2 font-bold text-black">Sub. Start</th>
                   <th className="px-2 py-2 font-bold text-black">Sub. End</th>
+                  <th className="px-2 py-2 font-bold text-black">Status</th>
                   <th className="px-2 py-2 font-bold text-black" />
                 </tr>
               </thead>
               <tbody>
                 {isLoading ? (
-                  <TableSkeleton rows={8} cols={10} />
+                  <TableSkeleton rows={8} cols={12} />
                 ) : !sortedRecords.length ? (
                   <EmptyState message="No assets found." />
                 ) : (
@@ -278,6 +280,9 @@ export default function AssetRegistryPage() {
                         idx % 2 === 0 ? 'bg-white' : 'bg-[#fafafa]',
                       )}
                     >
+                      <td className="border-r border-[#8f8f8f] px-2 py-2 text-center">
+                        {(activePage - 1) * PAGE_SIZE + idx + 1}
+                      </td>
                       <td className="border-r border-[#8f8f8f] px-2 py-2">
                         {formatDate(rec.lodge_date)}
                       </td>
@@ -304,6 +309,16 @@ export default function AssetRegistryPage() {
                       </td>
                       <td className="border-r border-[#8f8f8f] px-2 py-2">
                         {formatDate(rec.subscription_end_date)}
+                      </td>
+                      <td className="border-r border-[#8f8f8f] px-2 py-2">
+                        <span className={cn(
+                          'inline-block rounded px-1.5 py-0.5 text-[11px] font-semibold uppercase',
+                          rec.status === 'active'
+                            ? 'bg-green-100 text-green-800'
+                            : 'bg-red-100 text-red-700',
+                        )}>
+                          {rec.status}
+                        </span>
                       </td>
                       <td className="px-2 py-2">
                         <button

--- a/frontend/src/pages/CollateralPage.tsx
+++ b/frontend/src/pages/CollateralPage.tsx
@@ -227,15 +227,16 @@ export default function CollateralPage() {
                   <th className="px-2 py-2 font-bold text-right">Loan</th>
                   <th className="px-2 py-2 font-bold">Start</th>
                   <th className="px-2 py-2 font-bold">End</th>
+                  <th className="px-2 py-2 font-bold">Status</th>
                   <th className="px-2 py-2 font-bold" />
                 </tr>
               </thead>
               <tbody>
                 {loadingRecords ? (
-                  <TableSkeleton rows={8} cols={11} />
+                  <TableSkeleton rows={8} cols={12} />
                 ) : isError ? (
                   <tr>
-                    <td colSpan={11} className="py-6 text-center text-red-500">
+                    <td colSpan={12} className="py-6 text-center text-red-500">
                       Failed to load records.
                     </td>
                   </tr>
@@ -279,6 +280,18 @@ export default function CollateralPage() {
                       </td>
                       <td className="border-r border-[#8f8f8f] px-2 py-2">
                         {formatDate(rec.end_date)}
+                      </td>
+                      <td className="border-r border-[#8f8f8f] px-2 py-2">
+                        <span className={cn(
+                          'inline-block rounded px-1.5 py-0.5 text-[11px] font-semibold uppercase',
+                          rec.status === 'active'
+                            ? 'bg-green-100 text-green-800'
+                            : rec.status === 'pending_discharge'
+                              ? 'bg-amber-100 text-amber-800'
+                              : 'bg-slate-100 text-slate-600',
+                        )}>
+                          {rec.status === 'pending_discharge' ? 'Pending' : rec.status}
+                        </span>
                       </td>
                       <td className="px-2 py-2">
                         <button

--- a/frontend/src/pages/HirePurchasePage.tsx
+++ b/frontend/src/pages/HirePurchasePage.tsx
@@ -299,12 +299,13 @@ export default function HirePurchasePage() {
                   <th className="px-2 py-2 font-bold text-right">Amount</th>
                   <th className="px-2 py-2 font-bold">Start</th>
                   <th className="px-2 py-2 font-bold">End</th>
+                  <th className="px-2 py-2 font-bold">Status</th>
                   <th className="px-2 py-2 font-bold" />
                 </tr>
               </thead>
               <tbody>
                 {isLoading ? (
-                  <TableSkeleton rows={8} cols={11} />
+                  <TableSkeleton rows={8} cols={12} />
                 ) : !sortedRecords.length ? (
                   <EmptyState message="No hire purchase agreements found." />
                 ) : (
@@ -345,6 +346,18 @@ export default function HirePurchasePage() {
                       </td>
                       <td className="border-r border-[#8f8f8f] px-2 py-2">
                         {formatDate(rec.end_date)}
+                      </td>
+                      <td className="border-r border-[#8f8f8f] px-2 py-2">
+                        <span className={cn(
+                          'inline-block rounded px-1.5 py-0.5 text-[11px] font-semibold uppercase',
+                          rec.status === 'active'
+                            ? 'bg-green-100 text-green-800'
+                            : rec.status === 'pending_closure'
+                              ? 'bg-amber-100 text-amber-800'
+                              : 'bg-slate-100 text-slate-600',
+                        )}>
+                          {rec.status === 'pending_closure' ? 'Pending' : rec.status}
+                        </span>
                       </td>
                       <td className="px-2 py-2">
                         <button


### PR DESCRIPTION
Introduce new status states and management capabilities for collateral and hire purchase records.

- Add `pending_discharge` and `pending_closure` status handling in APIs and UI.
- Implement discharge functionality for collateral via `CollateralViewModal`.
- Implement closure confirmation functionality for hire purchase via `HirePurchaseViewModal`.
- Update asset registry, collateral, and hire purchase pages to display status badges and row numbering.
- Refactor API calls to use `PATCH` for status updates.