### PR TITLE
chore(config): add environment variable templates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,60 @@
+# ─── Django ───────────────────────────────────────────────────────────────────
+SECRET_KEY=your-secret-key-here
+DEBUG=True
+DEVELOPMENT=False
+ALLOWED_HOSTS=localhost,127.0.0.1
+
+# ─── Database ─────────────────────────────────────────────────────────────────
+# Local PostgreSQL (used when DEVELOPMENT=False and no PRODUCTION_DATABASE_URL)
+DB_ENGINE=django.db.backends.postgresql
+DB_NAME=assetsafe_db
+DB_USER=your_db_user
+DB_PASSWORD=your_db_password
+DB_HOST=127.0.0.1
+DB_PORT=5432
+
+# Production database URL — overrides the DB_* vars above when set
+# PRODUCTION_DATABASE_URL=postgresql://user:password@host:5432/dbname?sslmode=require
+
+# ─── Redis & Celery ───────────────────────────────────────────────────────────
+REDIS_HOST=localhost
+REDIS_PORT=6379
+REDIS_CACHE_LOCATION=redis://localhost:6379/1
+CELERY_BROKER_URL=redis://localhost:6379/0
+CELERY_RESULT_BACKEND=redis://localhost:6379/0
+CELERY_ACCEPT_CONTENT=['json']
+CELERY_TASK_SERIALIZER='json'
+
+# ─── Email ────────────────────────────────────────────────────────────────────
+EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend
+EMAIL_HOST=localhost
+EMAIL_PORT=1025
+EMAIL_USE_TLS=False
+EMAIL_USE_SSL=False
+EMAIL_HOST_USER=
+EMAIL_HOST_PASSWORD=
+DEFAULT_FROM_EMAIL=noreply@example.com
+
+# ─── App ──────────────────────────────────────────────────────────────────────
+PLATFORM_NAME=AssetSafe
+FRONTEND_URL=http://localhost:5173
+
+# ─── SMS ──────────────────────────────────────────────────────────────────────
+SMS_API_KEY=your_sms_api_key
+SMS_USERNAME=your_sms_username
+SMS_PASSWORD=your_sms_password
+
+# ─── Docker / Compose host ports ──────────────────────────────────────────────
+WEB_HOST_PORT=8000
+DB_HOST_PORT=5432
+REDIS_HOST_PORT=6379
+
+# ─── Entrypoint toggles ───────────────────────────────────────────────────────
+RUN_MIGRATIONS=1
+DJANGO_COLLECTSTATIC=0
+
+# ─── GitHub (optional — used for project board integration) ───────────────────
+# GITHUB_TOKEN=your_github_token
+# GITHUB_REPO_OWNER=your_github_username
+# GITHUB_REPO_NAME=your_repo_name
+# GITHUB_PROJECT_NUMBER=1

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,2 @@
+# Base URL for the Django API (no trailing slash)
+VITE_API_BASE_URL=http://localhost:8000/api


### PR DESCRIPTION
Add `.env.example` files to the root and frontend directories to provide templates for required environment variables.