### PR TITLE
Fix registry dashboard bugs and improve collateral/HP view-edit workflow

### DIFF
--- a/apps/collateral/api/serializers.py
+++ b/apps/collateral/api/serializers.py
@@ -35,6 +35,7 @@ class CollateralRegistrationSerializer(serializers.ModelSerializer):
     debtor_display = serializers.SerializerMethodField(read_only=True)
     data_source_display = serializers.SerializerMethodField(read_only=True)
     data_source_position = serializers.SerializerMethodField(read_only=True)
+    data_source_user_id = serializers.IntegerField(write_only=True, required=False)
     currency = serializers.SlugRelatedField(
         slug_field="code",
         queryset=Currency.objects.all(),
@@ -82,6 +83,7 @@ class CollateralRegistrationSerializer(serializers.ModelSerializer):
             "debtor_display",
             "data_source_display",
             "data_source_position",
+            "data_source_user_id",
         ]
         read_only_fields = [
             "id",
@@ -386,7 +388,36 @@ class CollateralRegistrationSerializer(serializers.ModelSerializer):
 
     @transaction.atomic
     def create(self, validated_data):
-        validated_data["created_by"] = self.context["request"].user
+        from django.contrib.auth import get_user_model
+
+        User = get_user_model()
+        request_user = self.context["request"].user
+        data_source_user_id = validated_data.pop("data_source_user_id", None)
+
+        if request_user.is_staff and data_source_user_id:
+            try:
+                data_source_user = User.objects.get(pk=data_source_user_id)
+            except User.DoesNotExist as exc:
+                raise serializers.ValidationError(
+                    {"data_source_user_id": "Invalid data source user."}
+                ) from exc
+
+            financier = validated_data.get("financier")
+            if (
+                not financier
+                or data_source_user.client_id != getattr(financier, "pk", financier)
+            ):
+                raise serializers.ValidationError(
+                    {
+                        "data_source_user_id": (
+                            "Data source user must belong to the selected financier."
+                        )
+                    }
+                )
+            validated_data["created_by"] = data_source_user
+        else:
+            validated_data["created_by"] = request_user
+
         return super().create(validated_data)
 
     @transaction.atomic

--- a/apps/collateral/api/views.py
+++ b/apps/collateral/api/views.py
@@ -17,7 +17,10 @@ from rest_framework.response import Response
 from rest_framework.exceptions import ValidationError
 
 from django_filters.rest_framework import DjangoFilterBackend
-from apps.common.utils.helpers import extract_error_message
+from apps.common.utils.helpers import (
+    extract_error_message,
+    scope_registry_to_client_portfolio,
+)
 from apps.users.utils.permissions import HasRole, roles_allowed
 from apps.asset_management.api.views import StandardResultsSetPagination
 from apps.collateral.models.models import CollateralRegistration
@@ -132,23 +135,13 @@ class CollateralRegistrationViewSet(BaseViewSet):
         Returns all collateral records with party relations eagerly loaded via
         ``select_related`` to prevent N+1 queries when list responses render
         ``financier_display`` and ``debtor_display``.
-        """
-        if self.request.user.roles.filter(
-            name__in=[
-                "client_user",
-                "client_admin",
-                "individual_client",
-                "company_client",
-            ]
-        ).exists():
-            return CollateralRegistration.objects.select_related(
-                "financier",
-                "individual_debtor",
-                "company_debtor",
-                "created_by",
-            ).filter(created_by__client=self.request.user.client)
 
-        return CollateralRegistration.objects.select_related(
+        Client users only see records belonging to their own portfolio, i.e.
+        records where their client is the ``financier``. This mirrors the
+        filter used by ``stats()`` so the list total and headline counts
+        never disagree.
+        """
+        qs = CollateralRegistration.objects.select_related(
             "financier",
             "individual_debtor",
             "company_debtor",
@@ -156,6 +149,16 @@ class CollateralRegistrationViewSet(BaseViewSet):
             "currency",
             "created_by",
         ).all()
+        qs = scope_registry_to_client_portfolio(qs, self.request.user)
+
+        # The main dashboard table should only surface active and
+        # pending-discharge agreements; already-discharged records are
+        # excluded from the list (but remain reachable directly by id for
+        # retrieve/update/delete/discharge).
+        if self.action == "list":
+            qs = qs.filter(is_discharged=False)
+
+        return qs
 
     # ------------------------------------------------------------------
     # Audit-logged CRUD hooks
@@ -175,7 +178,7 @@ class CollateralRegistrationViewSet(BaseViewSet):
             )
 
         except Exception as e:
-            logger.error(f"Error creating collateral registration: {e}")
+            logger.error("Error creating collateral registration: %s", e)
             return self._create_rendered_response(
                 {"error": "Something went wrong"},
                 status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -198,7 +201,7 @@ class CollateralRegistrationViewSet(BaseViewSet):
             )
 
         except Exception as e:
-            logger.error(f"Error updating collateral registration: {e}")
+            logger.error("Error updating collateral registration: %s", e)
             return self._create_rendered_response(
                 {"error": "Something went wrong"}, status.HTTP_500_INTERNAL_SERVER_ERROR
             )
@@ -208,12 +211,14 @@ class CollateralRegistrationViewSet(BaseViewSet):
             instance = self.get_object()
             self.perform_destroy(instance)
             logger.info(
-                f"Collateral registration with agreement number {instance.agreement_number} deleted by user {request.user}"
+                "Collateral registration with agreement number %s deleted by user %s",
+                instance.agreement_number,
+                request.user,
             )
             return Response(status=status.HTTP_204_NO_CONTENT)
 
         except Exception as e:
-            logger.error(f"Error deleting collateral registration: {e}")
+            logger.error("Error deleting collateral registration: %s", e)
             return self._create_rendered_response(
                 {"error": "Something went wrong"}, status.HTTP_500_INTERNAL_SERVER_ERROR
             )
@@ -280,14 +285,15 @@ class CollateralRegistrationViewSet(BaseViewSet):
 
         """
         today = timezone.now().date()
-        qs = CollateralRegistration.objects.all()
-        # Client users should only see their own portfolio totals.
-        if not request.user.is_staff and getattr(request.user, "client_id", None):
-            qs = qs.filter(financier_id=request.user.client_id)
+        qs = scope_registry_to_client_portfolio(
+            CollateralRegistration.objects.all(),
+            request.user,
+        )
 
         active_filter = Q(
             agreement_start_date__lte=today,
             agreement_end_date__gte=today,
+            is_discharged=False,
         )
         aggregates: dict = qs.aggregate(
             active_agreements=Count("id", filter=active_filter),

--- a/apps/collateral/api/views.py
+++ b/apps/collateral/api/views.py
@@ -69,7 +69,23 @@ class CollateralRegistrationViewSet(BaseViewSet):
         "currency",
         "debtor_type",
     ]
-    search_fields: list[str] = [
+    SEARCH_FIELD_MAP: dict[str, list[str]] = {
+        "agreement_number": ["agreement_number"],
+        "debtor": [
+            "individual_debtor__first_name",
+            "individual_debtor__last_name",
+            "individual_debtor__identification_number",
+            "company_debtor__branch_name",
+            "company_debtor__company__registration_name",
+            "company_debtor__company__trading_name",
+        ],
+        "reg_serial_number": [
+            "serial_number",
+            "asset_registration_number",
+            "chassis_number",
+        ],
+    }
+    DEFAULT_SEARCH_FIELDS: list[str] = [
         "agreement_number",
         "individual_debtor__first_name",
         "individual_debtor__last_name",
@@ -90,6 +106,17 @@ class CollateralRegistrationViewSet(BaseViewSet):
         "total_debt",
     ]
     ordering: list[str] = ["-lodge_date"]
+
+    @property
+    def search_fields(self) -> list[str]:
+        """
+        Scopes ``SearchFilter`` to the fields backing the selected
+        ``search_field`` criteria (e.g. "Agreement Number", "Debtor",
+        "Reg/Serial Number"). Any unrecognised/absent value searches the
+        full default field set.
+        """
+        search_field = self.request.query_params.get("search_field")
+        return self.SEARCH_FIELD_MAP.get(search_field, self.DEFAULT_SEARCH_FIELDS)
 
     def get_serializer_class(self):
         """

--- a/apps/common/utils/helpers.py
+++ b/apps/common/utils/helpers.py
@@ -1,8 +1,38 @@
+from __future__ import annotations
+
+from django.db.models import QuerySet
 from rest_framework.exceptions import ValidationError
+
+CLIENT_ROLE_NAMES: tuple[str, ...] = (
+    "client_user",
+    "client_admin",
+    "individual_client",
+    "company_client",
+)
+
+
+def scope_registry_to_client_portfolio(
+    queryset: QuerySet, user, *, financier_field: str = "financier_id"
+):
+    """
+    Limit client-role users to records where their organisation is the
+    financier.  Staff/admin users without those roles see the full registry.
+
+    Both list and stats endpoints must call this helper so headline counts
+    never disagree with the table below.
+    """
+    if (
+        user.is_authenticated
+        and user.client_id
+        and user.roles.filter(name__in=CLIENT_ROLE_NAMES).exists()
+    ):
+        return queryset.filter(**{financier_field: user.client_id})
+    return queryset
+
 
 def extract_error_message(error):
     """
-    Recursively extract the first human-readable error message 
+    Recursively extract the first human-readable error message
     from the Validation Error.
     """
     if isinstance(error, ValidationError):

--- a/apps/hire_purchase/api/serializers.py
+++ b/apps/hire_purchase/api/serializers.py
@@ -13,7 +13,6 @@ from rest_framework import serializers
 from apps.hire_purchase.models import HirePurchaseRegistration
 from apps.common.models import Currency
 
-
 # ---------------------------------------------------------------------------
 # Hire Purchase serializers
 # ---------------------------------------------------------------------------
@@ -279,9 +278,8 @@ class HirePurchaseRegistrationSerializer(serializers.ModelSerializer):
                 ) from exc
 
             financier = validated_data.get("financier")
-            if (
-                not financier
-                or data_source_user.client_id != getattr(financier, "pk", financier)
+            if not financier or data_source_user.client_id != getattr(
+                financier, "pk", financier
             ):
                 raise serializers.ValidationError(
                     {
@@ -302,6 +300,62 @@ class HirePurchaseRegistrationSerializer(serializers.ModelSerializer):
     ) -> HirePurchaseRegistration:
         validated_data["updated_by"] = self.context["request"].user
         return super().update(instance, validated_data)
+
+
+class HirePurchaseRegistrationListSerializer(HirePurchaseRegistrationSerializer):
+    """
+    Lightweight read-only serializer optimized for list endpoints and
+    dashboards, mirroring the shape returned by the Collateral and Asset
+    Registry list endpoints.
+    """
+
+    lodge_date = serializers.DateField(read_only=True, format="%d-%b-%y")
+    agreement_start_date = serializers.DateField(read_only=True, format="%d-%b-%y")
+    agreement_end_date = serializers.DateField(read_only=True, format="%d-%b-%y")
+    currency_code = serializers.CharField(source="currency.code", read_only=True)
+    description = serializers.SerializerMethodField(
+        read_only=True,
+        help_text="Concatenated make and model for display purposes.",
+    )
+    primary_identifier = serializers.SerializerMethodField(
+        read_only=True,
+        help_text="Returns the MV registration number for vehicles, or the serial number otherwise.",
+    )
+
+    class Meta(HirePurchaseRegistrationSerializer.Meta):
+        """Inherits from HirePurchaseRegistrationSerializer.Meta, but overrides fields to a smaller subset for list performance."""
+
+        fields = [
+            "id",
+            "lodge_date",
+            "agreement_number",
+            "financier_display",
+            "purchaser_display",
+            "description",
+            "primary_identifier",
+            "currency_code",
+            "purchase_amount",
+            "agreement_start_date",
+            "agreement_end_date",
+            "closure_confirmed",
+        ]
+        read_only_fields = fields
+
+    def get_description(self, obj: HirePurchaseRegistration) -> str:
+        """Gets the description for the asset, which is a concatenation of the make and model."""
+        if obj.make and obj.model:
+            return f"{obj.make} {obj.model}"
+        if obj.make:
+            return obj.make
+        if obj.model:
+            return obj.model
+        return ""
+
+    def get_primary_identifier(self, obj: HirePurchaseRegistration) -> str:
+        """Gets the primary identifier for the asset, which is the MV registration number for vehicles or the serial number for other asset types."""
+        if obj.asset_type == "vehicles":
+            return obj.mv_registration_number
+        return obj.serial_number
 
 
 class HirePurchaseClosureSerializer(serializers.ModelSerializer):

--- a/apps/hire_purchase/api/views.py
+++ b/apps/hire_purchase/api/views.py
@@ -61,7 +61,22 @@ class HirePurchaseRegistrationViewSet(BaseViewSet):
         "closure_confirmed",
         "currency",
     ]
-    search_fields: list[str] = [
+    SEARCH_FIELD_MAP: dict[str, list[str]] = {
+        "agreement_number": ["agreement_number"],
+        "purchaser": [
+            "purchaser_individual__first_name",
+            "purchaser_individual__last_name",
+            "purchaser_company__branch_name",
+            "purchaser_company__company__trading_name",
+            "purchaser_company__company__registration_name",
+        ],
+        "reg_serial_number": [
+            "serial_number",
+            "mv_registration_number",
+            "chassis_number",
+        ],
+    }
+    DEFAULT_SEARCH_FIELDS: list[str] = [
         "agreement_number",
         "purchaser_individual__first_name",
         "purchaser_individual__last_name",
@@ -82,6 +97,17 @@ class HirePurchaseRegistrationViewSet(BaseViewSet):
         "purchase_amount",
     ]
     ordering: list[str] = ["-lodge_date"]
+
+    @property
+    def search_fields(self) -> list[str]:
+        """
+        Scopes ``SearchFilter`` to the fields backing the selected
+        ``search_field`` criteria (e.g. "Agreement Number", "Purchaser Name",
+        "Reg/Serial Number"). Any unrecognised/absent value searches the
+        full default field set.
+        """
+        search_field = self.request.query_params.get("search_field")
+        return self.SEARCH_FIELD_MAP.get(search_field, self.DEFAULT_SEARCH_FIELDS)
 
     def get_queryset(self) -> QuerySet[HirePurchaseRegistration]:
         """

--- a/apps/hire_purchase/api/views.py
+++ b/apps/hire_purchase/api/views.py
@@ -20,13 +20,17 @@ from django_filters.rest_framework import DjangoFilterBackend
 
 from apps.asset_management.api.views import StandardResultsSetPagination
 from apps.common.api.views import BaseViewSet
-from apps.common.utils.helpers import extract_error_message
+from apps.common.utils.helpers import (
+    extract_error_message,
+    scope_registry_to_client_portfolio,
+)
 from apps.hire_purchase.models.models import HirePurchaseRegistration
 from apps.users.services.audit_service import create_audit_log
 from apps.users.utils.permissions import HasRole, roles_allowed
 from .serializers import (
     HirePurchaseClosureSerializer,
     HirePurchaseDashboardSerializer,
+    HirePurchaseRegistrationListSerializer,
     HirePurchaseRegistrationSerializer,
 )
 
@@ -109,16 +113,43 @@ class HirePurchaseRegistrationViewSet(BaseViewSet):
         search_field = self.request.query_params.get("search_field")
         return self.SEARCH_FIELD_MAP.get(search_field, self.DEFAULT_SEARCH_FIELDS)
 
+    def get_serializer_class(self):
+        """
+        Return the appropriate serializer class based on the requested action.
+        We return the lighter ListSerializer for list actions for performance,
+        matching the Collateral and Asset Registry list endpoints.
+        """
+        if self.action == "list":
+            return HirePurchaseRegistrationListSerializer
+        return super().get_serializer_class()
+
     def get_queryset(self) -> QuerySet[HirePurchaseRegistration]:
         """
         Returns all HP records eagerly loaded via ``select_related``.
+
+        Client users only see records belonging to their own portfolio, i.e.
+        records where their client is the ``financier``. This mirrors the
+        filter used by ``stats()`` so the list total and headline counts
+        never disagree.
+
+        The main dashboard table should only surface active and
+        pending-closure agreements; already-closed records are excluded
+        from the list (but remain reachable directly by id for
+        retrieve/update/delete/confirm-closure).
         """
-        return HirePurchaseRegistration.objects.select_related(
+        qs = HirePurchaseRegistration.objects.select_related(
             "financier",
             "purchaser_individual",
             "purchaser_company",
             "purchaser_company__company",
         ).all()
+
+        qs = scope_registry_to_client_portfolio(qs, self.request.user)
+
+        if self.action == "list":
+            qs = qs.filter(closure_confirmed=False)
+
+        return qs
 
     # ------------------------------------------------------------------
     # Audit-logged CRUD hooks
@@ -222,14 +253,21 @@ class HirePurchaseRegistrationViewSet(BaseViewSet):
     def stats(self, request: Request) -> Response:
         """
         Returns the three headline statistics shown at the top of the HP
+        dashboard.
         """
         today = timezone.now().date()
+        qs = scope_registry_to_client_portfolio(
+            HirePurchaseRegistration.objects.all(),
+            request.user,
+        )
 
-        # Single aggregate call for the two count metrics.
-        aggregates: dict = HirePurchaseRegistration.objects.aggregate(
+        # Single aggregate call for the two count metrics. `active_agreements`
+        # excludes already-closed records so it can never disagree with the
+        # main table, which only ever shows open (non-closed) agreements.
+        aggregates: dict = qs.aggregate(
             active_agreements=Count(
                 "id",
-                filter=Q(agreement_end_date__gte=today),
+                filter=Q(agreement_end_date__gte=today, closure_confirmed=False),
             ),
             pending_closure_confirmation=Count(
                 "id",
@@ -242,9 +280,7 @@ class HirePurchaseRegistrationViewSet(BaseViewSet):
 
         # Distinct-financier count: cannot be folded into the aggregate above
         # without a subquery, so a second lightweight query is used.
-        number_of_financiers: int = (
-            HirePurchaseRegistration.objects.values("financier_id").distinct().count()
-        )
+        number_of_financiers: int = qs.values("financier_id").distinct().count()
 
         serializer = HirePurchaseDashboardSerializer(
             data={

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -91,7 +91,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -638,10 +637,31 @@
         "@noble/ciphers": "^1.0.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1257,7 +1277,6 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -3687,6 +3706,37 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
       "version": "1.0.0-rc.17",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
@@ -4063,7 +4113,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.9.tgz",
       "integrity": "sha512-Oa44XkaI3kCNN6ME0KByU3xT3SEUNOMfZpHxL6+wFoTm+OeUFYHKdeYVe0aOXlRDm/f15sgLwEt2HDorIdW8+A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.100.9"
       },
@@ -4217,7 +4266,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
       "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -4228,7 +4276,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4239,7 +4286,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4310,7 +4356,6 @@
       "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.1",
         "@typescript-eslint/types": "8.59.1",
@@ -4579,7 +4624,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4936,7 +4980,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -5948,7 +5991,6 @@
       "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -6005,7 +6047,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -7246,7 +7287,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
       "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -8888,7 +8928,6 @@
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9246,7 +9285,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9256,7 +9294,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -9269,7 +9306,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.54.2.tgz",
       "integrity": "sha512-eHpAUgUjWbZocoQYUHposymRb4ZP6d0uwUnooL2uOybA9/3tPUvoAKqEWK1WaSiTxxOfTpffNZP7QwlnM3/gEg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -9679,7 +9715,6 @@
       "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.4.tgz",
       "integrity": "sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -10348,7 +10383,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10608,7 +10642,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -10942,7 +10975,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -55,9 +55,25 @@ const queryClient = new QueryClient({
 });
 
 // Simple React Query persistence using localStorage via dehydrate/hydrate
+//
+// NOTE: Bump the "v" suffix whenever a backend/API response shape or
+// filtering change means previously-cached data could be stale/incorrect.
+// Since `refetchOnMount` is disabled below, a hydrated cache entry is
+// served indefinitely (across reloads) until explicitly invalidated, so
+// changing this key is the way to force every browser to drop its old
+// persisted cache and fetch fresh data.
+const RQ_CACHE_KEY = 'RQ:cache:v3';
+
 if (typeof window !== 'undefined') {
   try {
-    const cached = window.localStorage.getItem('RQ:cache:v1');
+    // Clear out any older cache versions so stale entries don't linger.
+    for (const key of Object.keys(window.localStorage)) {
+      if (key.startsWith('RQ:cache:') && key !== RQ_CACHE_KEY) {
+        window.localStorage.removeItem(key);
+      }
+    }
+
+    const cached = window.localStorage.getItem(RQ_CACHE_KEY);
     if (cached) {
       const parsed = JSON.parse(cached);
       hydrate(queryClient, parsed);
@@ -66,7 +82,7 @@ if (typeof window !== 'undefined') {
     const persist = () => {
       try {
         const data = dehydrate(queryClient);
-        window.localStorage.setItem('RQ:cache:v1', JSON.stringify(data));
+        window.localStorage.setItem(RQ_CACHE_KEY, JSON.stringify(data));
       } catch {
         // ignore
       }

--- a/frontend/src/api/collateralApi.ts
+++ b/frontend/src/api/collateralApi.ts
@@ -71,7 +71,6 @@ function mapCollateralRecord(
 export const collateralApi = {
   getDashboard: async (params?: {
     search_field?: string;
-    search_value?: string;
   }): Promise<CollateralDashboard> => {
     const { data } = await axiosInstance.get('/collateral/stats/', { params });
     return unwrapApiData<CollateralDashboard>(data);
@@ -80,7 +79,6 @@ export const collateralApi = {
   getRecords: async (params?: {
     search?: string;
     search_field?: string;
-    search_value?: string;
     page?: number;
     page_size?: number;
   }): Promise<{ records: CollateralRecord[]; count: number }> => {

--- a/frontend/src/api/hirePurchaseApi.ts
+++ b/frontend/src/api/hirePurchaseApi.ts
@@ -80,6 +80,7 @@ export const hirePurchaseApi = {
   getRecords: async (params?: {
     financier_id?: number;
     search?: string;
+    search_field?: string;
     page?: number;
     page_size?: number;
   }): Promise<{ records: HirePurchaseRecord[]; count: number }> => {

--- a/frontend/src/api/hirePurchaseApi.ts
+++ b/frontend/src/api/hirePurchaseApi.ts
@@ -1,6 +1,6 @@
 import axiosInstance from './axiosInstance';
 import { mapHirePurchaseFormToApi } from '@/lib/registryPayloads';
-import { unwrapApiData } from '@/lib/parsePaginatedApi';
+import { parsePaginatedList, unwrapApiData } from '@/lib/parsePaginatedApi';
 import type {
   ApiResponse,
   HirePurchaseDashboard,
@@ -28,6 +28,9 @@ function mapHirePurchaseRecord(
         record.purchaser_company ??
         0,
     ),
+    asset_description: String(
+      record.description ?? `${record.make ?? ''} ${record.model ?? ''}`.trim(),
+    ),
     asset_make: String(record.make ?? record.asset_make ?? ''),
     asset_model: String(record.model ?? record.asset_model ?? ''),
     asset_type: String(record.asset_type ?? ''),
@@ -37,6 +40,7 @@ function mapHirePurchaseRecord(
     reg_serial_number: String(
       record.mv_registration_number ??
         record.serial_number ??
+        record.primary_identifier ??
         record.reg_serial_number ??
         '',
     ),
@@ -71,10 +75,10 @@ export const hirePurchaseApi = {
   getDashboard: async (params?: {
     financier_id?: number;
   }): Promise<HirePurchaseDashboard> => {
-    const { data } = await axiosInstance.get<
-      ApiResponse<HirePurchaseDashboard>
-    >('/hire-purchase/stats/', { params });
-    return data.data ?? (data as unknown as HirePurchaseDashboard);
+    const { data } = await axiosInstance.get('/hire-purchase/stats/', {
+      params,
+    });
+    return unwrapApiData<HirePurchaseDashboard>(data);
   },
 
   getRecords: async (params?: {
@@ -89,24 +93,10 @@ export const hirePurchaseApi = {
       ...rest,
       ...(financier_id ? { financier: financier_id } : {}),
     };
-    const { data } = await axiosInstance.get<any>('/hire-purchase/', {
+    const { data } = await axiosInstance.get('/hire-purchase/', {
       params: queryParams,
     });
-    const payload = data?.data ?? data;
-    const recordsRaw = payload?.results ?? payload?.data ?? payload ?? [];
-    const count =
-      typeof payload?.count === 'number'
-        ? payload.count
-        : Array.isArray(recordsRaw)
-          ? recordsRaw.length
-          : 0;
-    const records = Array.isArray(recordsRaw)
-      ? recordsRaw.map((record: Record<string, unknown>) =>
-          mapHirePurchaseRecord(record),
-        )
-      : [];
-
-    return { records, count };
+    return parsePaginatedList(data, mapHirePurchaseRecord);
   },
 
   getRecord: async (id: number): Promise<HirePurchaseRecord> => {

--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -73,13 +73,6 @@ export function AppSidebar() {
           <SidebarGroupLabel>Dashboard</SidebarGroupLabel>
           <SidebarGroupContent>
             <SidebarMenu>
-              {isStaff ? (
-                <SidebarNavLink
-                  to="/registry"
-                  icon={Package}
-                  label="Asset Registry"
-                />
-              ) : null}
               <SidebarNavLink
                 to="/collateral"
                 icon={Landmark}
@@ -90,6 +83,13 @@ export function AppSidebar() {
                 icon={HandCoins}
                 label="Hire Purchase Registry"
               />
+              {isStaff ? (
+                <SidebarNavLink
+                  to="/registry"
+                  icon={Package}
+                  label="Asset Registry"
+                />
+              ) : null}
             </SidebarMenu>
           </SidebarGroupContent>
         </SidebarGroup>

--- a/frontend/src/components/collateral/CollateralForm.tsx
+++ b/frontend/src/components/collateral/CollateralForm.tsx
@@ -1,7 +1,10 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useForm, useFormState, Controller } from 'react-hook-form';
 import { zodResolver } from '@/lib/zodResolver';
-import { applyApiValidationErrors, firstFormErrorMessage } from '@/lib/formErrors';
+import {
+  applyApiValidationErrors,
+  firstFormErrorMessage,
+} from '@/lib/formErrors';
 import type { FieldErrors } from 'react-hook-form';
 import { z } from 'zod';
 import { useMutation, useQuery } from '@tanstack/react-query';
@@ -15,6 +18,7 @@ import { Input } from '@/components/ui/input';
 import { DateInput } from '@/components/ui/DateInput';
 import AutocompleteInput from '@/components/shared/AutocompleteInput';
 import { Button } from '@/components/ui/button';
+import { ConfirmDialog } from '@/components/shared/ConfirmDialog';
 import { FormSectionHeader } from '@/components/shared/FormSectionHeader';
 import { FieldError } from '@/components/shared/FieldError';
 import { Modal } from '@/components/shared/Modal';
@@ -90,6 +94,10 @@ interface CollateralFormProps {
   onSuccessAndAddAnother?: () => void;
   isEdit?: boolean;
   recordId?: number;
+  /** Edit mode only: invoked when "Close" is clicked, to discharge the record. */
+  onDischarge?: () => void;
+  /** Edit mode only: loading state for the discharge action. */
+  dischargePending?: boolean;
 }
 
 export function CollateralForm({
@@ -103,6 +111,8 @@ export function CollateralForm({
   onSuccessAndAddAnother,
   isEdit,
   recordId,
+  onDischarge,
+  dischargePending,
 }: CollateralFormProps) {
   const user = useAuthStore((s) => s.user);
   const setUser = useAuthStore((s) => s.setUser);
@@ -127,10 +137,13 @@ export function CollateralForm({
   const isFirstFinancierClientTypeRender = useRef(true);
   const [debtorLabel, setDebtorLabel] = useState(debtorDisplayLabel ?? '');
   const isFirstDebtorTypeRender = useRef(true);
-  const [dataSourceUserId, setDataSourceUserId] = useState<number | undefined>();
+  const [dataSourceUserId, setDataSourceUserId] = useState<
+    number | undefined
+  >();
   const [staffDataSourceName, setStaffDataSourceName] = useState('');
   const [staffDataSourcePosition, setStaffDataSourcePosition] = useState('');
-  const [staffDataSourceSearchLabel, setStaffDataSourceSearchLabel] = useState('');
+  const [staffDataSourceSearchLabel, setStaffDataSourceSearchLabel] =
+    useState('');
 
   const clearDataSource = () => {
     setDataSourceUserId(undefined);
@@ -142,7 +155,7 @@ export function CollateralForm({
   const { register, handleSubmit, control, watch, setError, setValue } =
     useForm<FormValues>({
       resolver: zodResolver(formSchema),
-      mode: 'onSubmit',
+      mode: 'onBlur',
       reValidateMode: 'onChange',
       shouldFocusError: true,
       defaultValues: {
@@ -153,9 +166,7 @@ export function CollateralForm({
         total_paid_to_date: 0,
         instalment_amount: 0,
         instalment_date: 1,
-        ...(isClientUser
-          ? {}
-          : { financier_id: clientFinancierId }),
+        ...(isClientUser ? {} : { financier_id: clientFinancierId }),
         ...initial,
       },
     });
@@ -223,7 +234,10 @@ export function CollateralForm({
 
   useEffect(() => {
     if (isStaff || user?.client_id) return;
-    void authApi.me().then(setUser).catch(() => {});
+    void authApi
+      .me()
+      .then(setUser)
+      .catch(() => {});
   }, [isStaff, user?.client_id, setUser]);
 
   useEffect(() => {
@@ -257,7 +271,12 @@ export function CollateralForm({
   }, [selectedFinancierId, isEdit, isClientUser]);
 
   useEffect(() => {
-    if (isEdit || !isStaff || financierClientType !== 'individual' || !clientDetail) {
+    if (
+      isEdit ||
+      !isStaff ||
+      financierClientType !== 'individual' ||
+      !clientDetail
+    ) {
       return;
     }
     const details = clientDetail.client_details;
@@ -317,6 +336,8 @@ export function CollateralForm({
     (watch('loan_amount') ?? 0) - (watch('total_paid_to_date') ?? 0);
 
   const [addAnother, setAddAnother] = useState(false);
+  const [confirmingUpdate, setConfirmingUpdate] = useState(false);
+  const [pendingSubmit, setPendingSubmit] = useState<FormValues | null>(null);
 
   const { mutate: submit, isPending } = useMutation({
     mutationFn: (data: FormValues) =>
@@ -324,6 +345,8 @@ export function CollateralForm({
         ? collateralApi.updateRecord(recordId, data as any)
         : collateralApi.createRecord(data as any),
     onSuccess: () => {
+      setConfirmingUpdate(false);
+      setPendingSubmit(null);
       if (addAnother && onSuccessAndAddAnother) {
         onSuccessAndAddAnother();
       } else {
@@ -331,6 +354,7 @@ export function CollateralForm({
       }
     },
     onError: (err: unknown) => {
+      setConfirmingUpdate(false);
       setAddAnother(false);
       if (!applyApiValidationErrors(setError, err)) {
         const data = (
@@ -346,16 +370,14 @@ export function CollateralForm({
   const onInvalid = (formErrors: FieldErrors<FormValues>) => {
     setAddAnother(false);
     toast.error(
-      firstFormErrorMessage(formErrors) ??
-        'Please fix the highlighted fields',
+      firstFormErrorMessage(formErrors) ?? 'Please fix the highlighted fields',
     );
   };
 
   const buildSubmitPayload = (data: FormValues) => {
-    const payload =
-      isClientUser
-        ? ({ ...data, financier_id: clientFinancierId } as StaffFormValues)
-        : (data as StaffFormValues);
+    const payload = isClientUser
+      ? ({ ...data, financier_id: clientFinancierId } as StaffFormValues)
+      : (data as StaffFormValues);
 
     if (isStaff && !isEdit && dataSourceUserId) {
       return { ...payload, data_source_user_id: dataSourceUserId };
@@ -363,12 +385,23 @@ export function CollateralForm({
     return payload;
   };
 
+  const performSubmit = (data: FormValues) => {
+    submit(buildSubmitPayload(data) as any);
+  };
+
   const validateStaffDataSource = () => {
-    if (!isStaff || isEdit || !selectedFinancierId || Number(selectedFinancierId) <= 0) {
+    if (
+      !isStaff ||
+      isEdit ||
+      !selectedFinancierId ||
+      Number(selectedFinancierId) <= 0
+    ) {
       return true;
     }
     if (financierClientType === 'company' && !dataSourceUserId) {
-      toast.error('Please select a data source user for this company financier.');
+      toast.error(
+        'Please select a data source user for this company financier.',
+      );
       return false;
     }
     return true;
@@ -382,8 +415,19 @@ export function CollateralForm({
       return;
     }
     if (!validateStaffDataSource()) return;
-    submit(buildSubmitPayload(data) as any);
+    if (isEdit) {
+      setPendingSubmit(data);
+      setConfirmingUpdate(true);
+      return;
+    }
+    performSubmit(data);
   }, onInvalid);
+
+  const handleConfirmUpdate = () => {
+    if (pendingSubmit) {
+      performSubmit(pendingSubmit);
+    }
+  };
 
   return (
     <>
@@ -568,7 +612,8 @@ export function CollateralForm({
                           .filter(
                             (u) =>
                               u.name.toLowerCase().includes(term) ||
-                              (u.position?.toLowerCase().includes(term) ?? false),
+                              (u.position?.toLowerCase().includes(term) ??
+                                false),
                           )
                           .map((u) => ({
                             id: u.id,
@@ -877,34 +922,53 @@ export function CollateralForm({
 
         {/* ── Footer ── */}
         <div className="flex items-center justify-between border-t border-slate-200 bg-slate-50 px-4 py-3">
-          <Button type="button" variant="ghost" onClick={onCancel}>
-            {onSuccessAndAddAnother ? 'Done' : 'Cancel'}
-          </Button>
-          <div className="flex gap-2">
-            {onSuccessAndAddAnother && !isEdit && (
+          {isEdit ? (
+            <>
               <Button
                 type="submit"
                 variant="secondary"
-                loading={isPending && addAnother}
-                disabled={isPending && !addAnother}
-                onClick={() => setAddAnother(true)}
+                loading={isPending}
+                onClick={() => setAddAnother(false)}
               >
-                Save & Add Another
+                Update
               </Button>
-            )}
-            <Button
-              type="submit"
-              loading={isPending && !addAnother}
-              disabled={isPending && addAnother}
-              onClick={() => setAddAnother(false)}
-            >
-              {isEdit
-                ? 'Save Changes'
-                : onSuccessAndAddAnother
-                  ? 'Save'
-                  : 'Upload'}
-            </Button>
-          </div>
+              <Button
+                type="button"
+                variant="danger"
+                loading={dischargePending}
+                onClick={onDischarge}
+              >
+                Close
+              </Button>
+            </>
+          ) : (
+            <>
+              <Button type="button" variant="ghost" onClick={onCancel}>
+                {onSuccessAndAddAnother ? 'Done' : 'Cancel'}
+              </Button>
+              <div className="flex gap-2">
+                {onSuccessAndAddAnother && (
+                  <Button
+                    type="submit"
+                    variant="secondary"
+                    loading={isPending && addAnother}
+                    disabled={isPending && !addAnother}
+                    onClick={() => setAddAnother(true)}
+                  >
+                    Save & Add Another
+                  </Button>
+                )}
+                <Button
+                  type="submit"
+                  loading={isPending && !addAnother}
+                  disabled={isPending && addAnother}
+                  onClick={() => setAddAnother(false)}
+                >
+                  {onSuccessAndAddAnother ? 'Save' : 'Upload'}
+                </Button>
+              </div>
+            </>
+          )}
         </div>
       </form>
 
@@ -959,6 +1023,20 @@ export function CollateralForm({
           }}
         />
       </Modal>
+
+      <ConfirmDialog
+        open={confirmingUpdate}
+        title="Confirm Update"
+        message="Are you sure you want to save these changes?"
+        confirmLabel="Yes, Update"
+        variant="primary"
+        loading={isPending}
+        onConfirm={handleConfirmUpdate}
+        onCancel={() => {
+          setConfirmingUpdate(false);
+          setPendingSubmit(null);
+        }}
+      />
     </>
   );
 }

--- a/frontend/src/components/collateral/CollateralForm.tsx
+++ b/frontend/src/components/collateral/CollateralForm.tsx
@@ -67,6 +67,17 @@ type CoreFormValues = z.infer<typeof collateralCoreSchema>;
 type StaffFormValues = z.infer<typeof staffCollateralSchema>;
 type FormValues = CoreFormValues & { financier_id?: number };
 
+function ReadOnlyField({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="space-y-1">
+      <label className="text-xs font-medium text-slate-700">{label}</label>
+      <div className="flex h-8 w-full items-center rounded-sm border border-slate-200 bg-slate-50 px-2.5 text-sm text-slate-800">
+        {value || '—'}
+      </div>
+    </div>
+  );
+}
+
 interface CollateralFormProps {
   initial?: Partial<FormValues>;
   financierDisplayLabel?: string;
@@ -116,6 +127,17 @@ export function CollateralForm({
   const isFirstFinancierClientTypeRender = useRef(true);
   const [debtorLabel, setDebtorLabel] = useState(debtorDisplayLabel ?? '');
   const isFirstDebtorTypeRender = useRef(true);
+  const [dataSourceUserId, setDataSourceUserId] = useState<number | undefined>();
+  const [staffDataSourceName, setStaffDataSourceName] = useState('');
+  const [staffDataSourcePosition, setStaffDataSourcePosition] = useState('');
+  const [staffDataSourceSearchLabel, setStaffDataSourceSearchLabel] = useState('');
+
+  const clearDataSource = () => {
+    setDataSourceUserId(undefined);
+    setStaffDataSourceName('');
+    setStaffDataSourcePosition('');
+    setStaffDataSourceSearchLabel('');
+  };
 
   const { register, handleSubmit, control, watch, setError, setValue } =
     useForm<FormValues>({
@@ -153,6 +175,28 @@ export function CollateralForm({
   const partyTypeOptions = choices.PartyType ?? [];
   const assetTypeOptions = choices.CollateralAssetType ?? [];
   const assetConditionOptions = choices.AssetCondition ?? [];
+  const selectedFinancierId = watch('financier_id');
+
+  const { data: clientUsers = [] } = useQuery({
+    queryKey: ['collateral-client-users', selectedFinancierId],
+    queryFn: () => clientsApi.listClientUsers(Number(selectedFinancierId)),
+    enabled:
+      !isEdit &&
+      isStaff &&
+      !!selectedFinancierId &&
+      Number(selectedFinancierId) > 0,
+  });
+
+  const { data: clientDetail } = useQuery({
+    queryKey: ['collateral-client-detail', selectedFinancierId],
+    queryFn: () => clientsApi.getClient(Number(selectedFinancierId)),
+    enabled:
+      !isEdit &&
+      isStaff &&
+      financierClientType === 'individual' &&
+      !!selectedFinancierId &&
+      Number(selectedFinancierId) > 0,
+  });
 
   useEffect(() => {
     if (!watch('currency') && currencies.length > 0) {
@@ -197,7 +241,7 @@ export function CollateralForm({
   ]);
 
   useEffect(() => {
-    if (isClientUser) return;
+    if (isClientUser || isEdit) return;
     if (isFirstFinancierClientTypeRender.current) {
       isFirstFinancierClientTypeRender.current = false;
       return;
@@ -205,10 +249,41 @@ export function CollateralForm({
     setValue('financier_id', 0 as unknown as number);
     setFinancierLabel('');
     setAddClientOpen(false);
-  }, [financierClientType, isClientUser, setValue]);
+  }, [financierClientType, isClientUser, isEdit, setValue]);
+
+  useEffect(() => {
+    if (isEdit || isClientUser) return;
+    clearDataSource();
+  }, [selectedFinancierId, isEdit, isClientUser]);
+
+  useEffect(() => {
+    if (isEdit || !isStaff || financierClientType !== 'individual' || !clientDetail) {
+      return;
+    }
+    const details = clientDetail.client_details;
+    const individualName =
+      (details?.full_name ??
+        `${details?.first_name ?? ''} ${details?.last_name ?? ''}`.trim()) ||
+      clientDetail.name;
+    setStaffDataSourceName(individualName);
+    setStaffDataSourceSearchLabel(individualName);
+    setStaffDataSourcePosition('');
+  }, [clientDetail, financierClientType, isEdit, isStaff]);
+
+  useEffect(() => {
+    if (isEdit || !isStaff || financierClientType !== 'individual') return;
+    if (clientUsers.length === 1) {
+      const linkedUser = clientUsers[0];
+      setDataSourceUserId(linkedUser.id);
+      if (linkedUser.position) {
+        setStaffDataSourcePosition(linkedUser.position);
+      }
+    }
+  }, [clientUsers, financierClientType, isEdit, isStaff]);
 
   const watchedDebtorType = watch('debtor_type');
   useEffect(() => {
+    if (isEdit) return;
     if (isFirstDebtorTypeRender.current) {
       isFirstDebtorTypeRender.current = false;
       return;
@@ -217,7 +292,24 @@ export function CollateralForm({
     setDebtorLabel('');
     setAddIndividualOpen(false);
     setAddCompanyOpen(false);
-  }, [watchedDebtorType, setValue]);
+  }, [watchedDebtorType, isEdit, setValue]);
+
+  useEffect(() => {
+    if (debtorDisplayLabel) {
+      setDebtorLabel(debtorDisplayLabel);
+    }
+  }, [debtorDisplayLabel]);
+
+  useEffect(() => {
+    if (financierDisplayLabel) {
+      setFinancierLabel(financierDisplayLabel);
+    }
+  }, [financierDisplayLabel]);
+
+  const debtorTypeLabel =
+    partyTypeOptions.find(
+      (option: { value: string }) => option.value === watchedDebtorType,
+    )?.label ?? watchedDebtorType;
 
   const watchedAssetType = watch('asset_type');
   const isVehicle = watchedAssetType === 'vehicles';
@@ -259,18 +351,38 @@ export function CollateralForm({
     );
   };
 
+  const buildSubmitPayload = (data: FormValues) => {
+    const payload =
+      isClientUser
+        ? ({ ...data, financier_id: clientFinancierId } as StaffFormValues)
+        : (data as StaffFormValues);
+
+    if (isStaff && !isEdit && dataSourceUserId) {
+      return { ...payload, data_source_user_id: dataSourceUserId };
+    }
+    return payload;
+  };
+
+  const validateStaffDataSource = () => {
+    if (!isStaff || isEdit || !selectedFinancierId || Number(selectedFinancierId) <= 0) {
+      return true;
+    }
+    if (financierClientType === 'company' && !dataSourceUserId) {
+      toast.error('Please select a data source user for this company financier.');
+      return false;
+    }
+    return true;
+  };
+
   const onFormSubmit = handleSubmit((data) => {
-    if (isClientUser) {
-      if (!clientFinancierId) {
-        toast.error(
-          'Unable to load your financier profile. Please refresh and try again.',
-        );
-        return;
-      }
-      submit({ ...data, financier_id: clientFinancierId } as StaffFormValues);
+    if (isClientUser && !clientFinancierId) {
+      toast.error(
+        'Unable to load your financier profile. Please refresh and try again.',
+      );
       return;
     }
-    submit(data as StaffFormValues);
+    if (!validateStaffDataSource()) return;
+    submit(buildSubmitPayload(data) as any);
   }, onInvalid);
 
   return (
@@ -278,7 +390,47 @@ export function CollateralForm({
       <form onSubmit={onFormSubmit} className="bg-white" noValidate>
         {/* ── Financier Section ── */}
         <FormSectionHeader title="Financier" variant="teal" />
-        {isClientUser ? (
+        {isEdit ? (
+          <>
+            <div className="grid grid-cols-2 gap-3 p-4 pb-2 sm:grid-cols-4">
+              <div className="col-span-2">
+                <ReadOnlyField
+                  label="Financier Name"
+                  value={financierLabel || financierDisplayLabel || ''}
+                />
+              </div>
+              <Controller
+                name="data_date"
+                control={control}
+                render={({ field, fieldState }) => (
+                  <DateInput
+                    label="Data Date"
+                    value={field.value}
+                    onChange={field.onChange}
+                    onBlur={field.onBlur}
+                    error={fieldState.error?.message}
+                    required
+                    disabled
+                  />
+                )}
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-3 px-4 pb-4 sm:grid-cols-4">
+              <div className="col-span-2">
+                <ReadOnlyField
+                  label="Data Source Name"
+                  value={dataSourceDisplayLabel ?? user?.name ?? ''}
+                />
+              </div>
+              <div className="col-span-2">
+                <ReadOnlyField
+                  label="Position"
+                  value={dataSourcePositionLabel ?? user?.position ?? ''}
+                />
+              </div>
+            </div>
+          </>
+        ) : isClientUser ? (
           <>
             <div className="grid grid-cols-2 gap-3 p-4 pb-2 sm:grid-cols-4">
               <div className="col-span-2 space-y-1">
@@ -308,6 +460,7 @@ export function CollateralForm({
                     onBlur={field.onBlur}
                     error={fieldState.error?.message}
                     required
+                    disabled
                   />
                 )}
               />
@@ -318,9 +471,7 @@ export function CollateralForm({
                   Data Source Name
                 </label>
                 <div className="flex h-8 w-full items-center rounded-sm border border-slate-200 bg-slate-50 px-2.5 text-sm text-slate-800">
-                  {isEdit
-                    ? (dataSourceDisplayLabel ?? user?.name ?? '—')
-                    : (user?.name ?? '—')}
+                  {user?.name ?? '—'}
                 </div>
               </div>
               <div className="col-span-2 space-y-1">
@@ -328,9 +479,7 @@ export function CollateralForm({
                   Position
                 </label>
                 <div className="flex h-8 w-full items-center rounded-sm border border-slate-200 bg-slate-50 px-2.5 text-sm text-slate-800">
-                  {isEdit
-                    ? (dataSourcePositionLabel ?? user?.position ?? '—')
-                    : (user?.position ?? '—')}
+                  {user?.position ?? '—'}
                 </div>
               </div>
             </div>
@@ -397,10 +546,60 @@ export function CollateralForm({
                     onBlur={field.onBlur}
                     error={fieldState.error?.message}
                     required
+                    disabled
                   />
                 )}
               />
             </div>
+            {selectedFinancierId && Number(selectedFinancierId) > 0 ? (
+              <div className="grid grid-cols-2 gap-3 px-4 pb-4 sm:grid-cols-4">
+                <div className="col-span-2">
+                  {financierClientType === 'company' ? (
+                    <AutocompleteInput
+                      label="Data Source Name"
+                      placeholder="Search user under client..."
+                      queryKey={`collateral-data-source-${selectedFinancierId}`}
+                      displayLabel={staffDataSourceSearchLabel}
+                      minChars={1}
+                      fetchFn={async (q) => {
+                        const term = q.trim().toLowerCase();
+                        if (!term) return [];
+                        return clientUsers
+                          .filter(
+                            (u) =>
+                              u.name.toLowerCase().includes(term) ||
+                              (u.position?.toLowerCase().includes(term) ?? false),
+                          )
+                          .map((u) => ({
+                            id: u.id,
+                            name: u.name,
+                            subtitle: u.position,
+                          }));
+                      }}
+                      value={dataSourceUserId}
+                      onChange={(id) => {
+                        const selected = clientUsers.find((u) => u.id === id);
+                        setDataSourceUserId(id);
+                        setStaffDataSourceName(selected?.name ?? '');
+                        setStaffDataSourcePosition(selected?.position ?? '');
+                        setStaffDataSourceSearchLabel(selected?.name ?? '');
+                      }}
+                    />
+                  ) : (
+                    <ReadOnlyField
+                      label="Data Source Name"
+                      value={staffDataSourceName}
+                    />
+                  )}
+                </div>
+                <div className="col-span-2">
+                  <ReadOnlyField
+                    label="Position"
+                    value={staffDataSourcePosition}
+                  />
+                </div>
+              </div>
+            ) : null}
             {isStaff && (
               <div className="flex gap-2 px-4 pb-4">
                 <Button
@@ -419,70 +618,84 @@ export function CollateralForm({
 
         {/* ── Debtor Section ── */}
         <FormSectionHeader title="Debtor" variant="teal" />
-        <div className="flex gap-2 px-4 pt-2 pb-1">
-          <Button
-            type="button"
-            size="sm"
-            variant="primary"
-            leftIcon={<UserPlus className="h-3 w-3" />}
-            onClick={() => setAddIndividualOpen(true)}
-          >
-            + Add Individual
-          </Button>
-          <Button
-            type="button"
-            size="sm"
-            variant="secondary"
-            leftIcon={<Building className="h-3 w-3" />}
-            onClick={() => setAddCompanyOpen(true)}
-          >
-            + Add Company
-          </Button>
-        </div>
-        <div className="grid grid-cols-2 gap-3 p-4 sm:grid-cols-4">
-          <div>
-            <label className="text-xs font-medium text-slate-600">
-              Debtor Type
-            </label>
-            <select
-              {...register('debtor_type')}
-              className="mt-1 h-8 w-full rounded border border-slate-300 bg-white px-2 text-sm focus:outline-none focus:border-[#0f7d8e]"
-              disabled={!partyTypeOptions.length}
+        {!isEdit && (
+          <div className="flex gap-2 px-4 pt-2 pb-1">
+            <Button
+              type="button"
+              size="sm"
+              variant="primary"
+              leftIcon={<UserPlus className="h-3 w-3" />}
+              onClick={() => setAddIndividualOpen(true)}
             >
-              <option value="">
-                {partyTypeOptions.length ? 'Select type...' : 'Loading...'}
-              </option>
-              {partyTypeOptions.map((option: any) => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
+              + Add Individual
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="secondary"
+              leftIcon={<Building className="h-3 w-3" />}
+              onClick={() => setAddCompanyOpen(true)}
+            >
+              + Add Company
+            </Button>
+          </div>
+        )}
+        {isEdit ? (
+          <div className="grid grid-cols-2 gap-3 p-4 sm:grid-cols-4">
+            <ReadOnlyField label="Debtor Type" value={debtorTypeLabel} />
+            <div className="col-span-3">
+              <ReadOnlyField
+                label="Debtor"
+                value={debtorLabel || debtorDisplayLabel || ''}
+              />
+            </div>
+          </div>
+        ) : (
+          <div className="grid grid-cols-2 gap-3 p-4 sm:grid-cols-4">
+            <div>
+              <label className="text-xs font-medium text-slate-600">
+                Debtor Type
+              </label>
+              <select
+                {...register('debtor_type')}
+                className="mt-1 h-8 w-full rounded border border-slate-300 bg-white px-2 text-sm focus:outline-none focus:border-[#0f7d8e]"
+                disabled={!partyTypeOptions.length}
+              >
+                <option value="">
+                  {partyTypeOptions.length ? 'Select type...' : 'Loading...'}
                 </option>
-              ))}
-            </select>
+                {partyTypeOptions.map((option: any) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="col-span-3">
+              <Controller
+                name="debtor_id"
+                control={control}
+                render={({ field }) => (
+                  <AutocompleteInput
+                    label="Name / ID / Reg. No."
+                    placeholder="Search debtor..."
+                    queryKey={`collateral-debtor-${watch('debtor_type')}`}
+                    displayLabel={debtorLabel}
+                    fetchFn={(q) =>
+                      watch('debtor_type') === 'company'
+                        ? companiesApi.searchBranches(q)
+                        : individualsApi.searchIndividuals(q)
+                    }
+                    error={errors.debtor_id?.message}
+                    value={field.value}
+                    onBlur={field.onBlur}
+                    onChange={(v) => field.onChange(Number(v))}
+                  />
+                )}
+              />
+            </div>
           </div>
-          <div className="col-span-3">
-            <Controller
-              name="debtor_id"
-              control={control}
-              render={({ field }) => (
-                <AutocompleteInput
-                  label="Name / ID / Reg. No."
-                  placeholder="Search debtor..."
-                  queryKey={`collateral-debtor-${watch('debtor_type')}`}
-                  displayLabel={debtorLabel}
-                  fetchFn={(q) =>
-                    watch('debtor_type') === 'company'
-                      ? companiesApi.searchBranches(q)
-                      : individualsApi.searchIndividuals(q)
-                  }
-                  error={errors.debtor_id?.message}
-                  value={field.value}
-                  onBlur={field.onBlur}
-                  onChange={(v) => field.onChange(Number(v))}
-                />
-              )}
-            />
-          </div>
-        </div>
+        )}
 
         {/* ── Agreement & Asset Details ── */}
         <FormSectionHeader title="Agreement & Asset Details" variant="dark" />

--- a/frontend/src/components/collateral/CollateralViewModal.tsx
+++ b/frontend/src/components/collateral/CollateralViewModal.tsx
@@ -2,27 +2,25 @@ import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { Modal } from '@/components/shared/Modal';
+import { ConfirmDialog } from '@/components/shared/ConfirmDialog';
 import { CollateralForm } from './CollateralForm';
 import type { CollateralRecord } from '@/types';
 import { formatCurrency, formatDate } from '@/lib/utils';
 import { assetTypeLabel } from '@/lib/assetTypes';
 import { Button } from '@/components/ui/button';
-import { Edit, CheckCircle } from 'lucide-react';
-import { DeleteRecordButton } from '@/components/shared/DeleteRecordButton';
+import { Edit } from 'lucide-react';
 import { collateralApi } from '@/api/collateralApi';
 
 interface CollateralViewModalProps {
   record: CollateralRecord;
   onClose: () => void;
   onSaved: () => void;
-  onDeleted: () => void;
 }
 
 export function CollateralViewModal({
   record,
   onClose,
   onSaved,
-  onDeleted,
 }: CollateralViewModalProps) {
   const [editMode, setEditMode] = useState(false);
   const [confirmingDischarge, setConfirmingDischarge] = useState(false);
@@ -33,8 +31,6 @@ export function CollateralViewModal({
     queryFn: () => collateralApi.getRecord(record.id),
     staleTime: 5 * 60 * 1000,
   });
-
-  const currentStatus = detail?.status ?? record.status;
 
   const { mutate: discharge, isPending: isDischarging } = useMutation({
     mutationFn: () => collateralApi.dischargeRecord(record.id),
@@ -55,159 +51,122 @@ export function CollateralViewModal({
   });
 
   return (
-    <Modal
-      open
-      onClose={onClose}
-      title={`Collateral — ${record.agreement_number}`}
-      size="xl"
-    >
-      {editMode ? (
-        detail ? (
-          <CollateralForm
-            isEdit
-            recordId={record.id}
-            financierDisplayLabel={detail.financier_name}
-            dataSourceDisplayLabel={detail.data_source_display}
-            dataSourcePositionLabel={detail.data_source_position}
-            debtorDisplayLabel={detail.debtor_name}
-            initial={{
-              financier_id: detail.financier_id,
-              data_date: detail.data_date,
-              debtor_type: detail.debtor_type,
-              debtor_id: detail.debtor_id,
-              agreement_number: detail.agreement_number,
-              asset_type: detail.asset_type,
-              asset_make: detail.asset_make,
-              asset_model: detail.asset_model,
-              asset_year: detail.asset_year,
-              asset_condition: detail.asset_condition,
-              asset_registration_no: detail.asset_registration_no,
-              chassis_number: detail.chassis_number,
-              engine_number: detail.engine_number,
-              serial_number: detail.serial_number,
-              currency: detail.currency,
-              loan_amount: detail.loan_amount,
-              instalment_amount: detail.instalment_amount,
-              instalment_date: detail.instalment_date,
-              total_paid_to_date: detail.total_paid_to_date,
-              start_date: detail.start_date,
-              end_date: detail.end_date,
-            }}
-            onSuccess={onSaved}
-            onCancel={() => setEditMode(false)}
-          />
-        ) : (
-          <div className="flex items-center justify-center p-10 text-sm text-slate-400">
-            Loading…
-          </div>
-        )
-      ) : (
-        <div className="p-5 space-y-4 bg-white">
-          {/* Detail grid */}
-          <div className="grid grid-cols-2 gap-x-8 gap-y-3 text-sm sm:grid-cols-3">
-            {[
-              ['Financier', detail?.financier_name ?? record.financier_name],
-              [
-                'Data Source Name',
-                detail?.data_source_display ?? record.data_source_display,
-              ],
-              [
-                'Position',
-                detail?.data_source_position ?? record.data_source_position,
-              ],
-              ['Debtor', detail?.debtor_name ?? record.debtor_name],
-              ['Agreement No.', record.agreement_number],
-              [
-                'Asset',
-                `${detail?.asset_make ?? ''} ${detail?.asset_model ?? ''}`.trim() ||
-                  record.asset_description,
-              ],
-              [
-                'Asset Type',
-                assetTypeLabel(detail?.asset_type ?? record.asset_type),
-              ],
-              ['Year', detail?.asset_year ?? record.asset_year],
-              ['Condition', detail?.asset_condition ?? record.asset_condition],
-              [
-                'Reg/Serial',
-                detail?.serial_number ||
-                  detail?.asset_registration_no ||
-                  record.serial_number ||
-                  record.asset_registration_no,
-              ],
-              ['Currency', detail?.currency ?? record.currency],
-              [
-                'Loan Amount',
-                formatCurrency(detail?.loan_amount ?? record.loan_amount),
-              ],
-              [
-                'Instalment',
-                formatCurrency(
-                  detail?.instalment_amount ?? record.instalment_amount,
-                ),
-              ],
-              ['Balance', formatCurrency(detail?.balance ?? record.balance)],
-              [
-                'Start Date',
-                formatDate(detail?.start_date ?? record.start_date),
-              ],
-              ['End Date', formatDate(detail?.end_date ?? record.end_date)],
-              ['Status', detail?.status ?? record.status],
-            ].map(([k, v]) => (
-              <div key={String(k)}>
-                <dt className="text-xs font-medium uppercase text-slate-400">
-                  {k}
-                </dt>
-                <dd className="mt-0.5 font-medium text-slate-800">
-                  {String(v ?? '—')}
-                </dd>
-              </div>
-            ))}
-          </div>
-          <div className="flex flex-wrap items-center justify-between gap-2 pt-2 border-t border-slate-100">
-            <DeleteRecordButton
-              onDelete={() => collateralApi.deleteRecord(record.id)}
-              onDeleted={onDeleted}
+    <>
+      <Modal
+        open
+        onClose={onClose}
+        title={`Collateral — ${record.agreement_number}`}
+        size="xl"
+      >
+        {editMode ? (
+          detail ? (
+            <CollateralForm
+              isEdit
+              recordId={record.id}
+              financierDisplayLabel={detail.financier_name}
+              dataSourceDisplayLabel={detail.data_source_display}
+              dataSourcePositionLabel={detail.data_source_position}
+              debtorDisplayLabel={detail.debtor_name}
+              initial={{
+                financier_id: detail.financier_id,
+                data_date: detail.data_date,
+                debtor_type: detail.debtor_type,
+                debtor_id: detail.debtor_id,
+                agreement_number: detail.agreement_number,
+                asset_type: detail.asset_type,
+                asset_make: detail.asset_make,
+                asset_model: detail.asset_model,
+                asset_year: detail.asset_year,
+                asset_condition: detail.asset_condition,
+                asset_registration_no: detail.asset_registration_no,
+                chassis_number: detail.chassis_number,
+                engine_number: detail.engine_number,
+                serial_number: detail.serial_number,
+                currency: detail.currency,
+                loan_amount: detail.loan_amount,
+                instalment_amount: detail.instalment_amount,
+                instalment_date: detail.instalment_date,
+                total_paid_to_date: detail.total_paid_to_date,
+                start_date: detail.start_date,
+                end_date: detail.end_date,
+              }}
+              onSuccess={onSaved}
+              onCancel={() => setEditMode(false)}
+              onDischarge={() => setConfirmingDischarge(true)}
+              dischargePending={isDischarging}
             />
-            <div className="flex gap-2 items-center">
-              {currentStatus !== 'discharged' &&
-                (confirmingDischarge ? (
-                  <>
-                    <span className="text-xs text-amber-700">
-                      Confirm discharge?
-                    </span>
-                    <Button
-                      type="button"
-                      size="sm"
-                      variant="primary"
-                      loading={isDischarging}
-                      onClick={() => discharge()}
-                    >
-                      Yes, Discharge
-                    </Button>
-                    <Button
-                      type="button"
-                      size="sm"
-                      variant="ghost"
-                      onClick={() => setConfirmingDischarge(false)}
-                    >
-                      Cancel
-                    </Button>
-                  </>
-                ) : (
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="secondary"
-                    leftIcon={<CheckCircle className="h-3.5 w-3.5" />}
-                    onClick={() => setConfirmingDischarge(true)}
-                  >
-                    Discharge
-                  </Button>
-                ))}
-              <Button variant="ghost" onClick={onClose}>
-                Close
-              </Button>
+          ) : (
+            <div className="flex items-center justify-center p-10 text-sm text-slate-400">
+              Loading…
+            </div>
+          )
+        ) : (
+          <div className="p-5 space-y-4 bg-white">
+            {/* Detail grid */}
+            <div className="grid grid-cols-2 gap-x-8 gap-y-3 text-sm sm:grid-cols-3">
+              {[
+                ['Financier', detail?.financier_name ?? record.financier_name],
+                [
+                  'Data Source Name',
+                  detail?.data_source_display ?? record.data_source_display,
+                ],
+                [
+                  'Position',
+                  detail?.data_source_position ?? record.data_source_position,
+                ],
+                ['Debtor', detail?.debtor_name ?? record.debtor_name],
+                ['Agreement No.', record.agreement_number],
+                [
+                  'Asset',
+                  `${detail?.asset_make ?? ''} ${detail?.asset_model ?? ''}`.trim() ||
+                    record.asset_description,
+                ],
+                [
+                  'Asset Type',
+                  assetTypeLabel(detail?.asset_type ?? record.asset_type),
+                ],
+                ['Year', detail?.asset_year ?? record.asset_year],
+                [
+                  'Condition',
+                  detail?.asset_condition ?? record.asset_condition,
+                ],
+                [
+                  'Reg/Serial',
+                  detail?.serial_number ||
+                    detail?.asset_registration_no ||
+                    record.serial_number ||
+                    record.asset_registration_no,
+                ],
+                ['Currency', detail?.currency ?? record.currency],
+                [
+                  'Loan Amount',
+                  formatCurrency(detail?.loan_amount ?? record.loan_amount),
+                ],
+                [
+                  'Instalment',
+                  formatCurrency(
+                    detail?.instalment_amount ?? record.instalment_amount,
+                  ),
+                ],
+                ['Balance', formatCurrency(detail?.balance ?? record.balance)],
+                [
+                  'Start Date',
+                  formatDate(detail?.start_date ?? record.start_date),
+                ],
+                ['End Date', formatDate(detail?.end_date ?? record.end_date)],
+                ['Status', detail?.status ?? record.status],
+              ].map(([k, v]) => (
+                <div key={String(k)}>
+                  <dt className="text-xs font-medium uppercase text-slate-400">
+                    {k}
+                  </dt>
+                  <dd className="mt-0.5 font-medium text-slate-800">
+                    {String(v ?? '—')}
+                  </dd>
+                </div>
+              ))}
+            </div>
+            <div className="flex items-center justify-end gap-2 pt-2 border-t border-slate-100">
               <Button
                 leftIcon={<Edit className="h-3.5 w-3.5" />}
                 onClick={() => setEditMode(true)}
@@ -216,8 +175,19 @@ export function CollateralViewModal({
               </Button>
             </div>
           </div>
-        </div>
-      )}
-    </Modal>
+        )}
+      </Modal>
+
+      <ConfirmDialog
+        open={confirmingDischarge}
+        title="Confirm Close"
+        message="Are you sure you want to mark this collateral as discharged?"
+        confirmLabel="Yes, Discharge"
+        variant="danger"
+        loading={isDischarging}
+        onConfirm={() => discharge()}
+        onCancel={() => setConfirmingDischarge(false)}
+      />
+    </>
   );
 }

--- a/frontend/src/components/collateral/CollateralViewModal.tsx
+++ b/frontend/src/components/collateral/CollateralViewModal.tsx
@@ -180,7 +180,7 @@ export function CollateralViewModal({
 
       <ConfirmDialog
         open={confirmingDischarge}
-        title="Confirm Close"
+        title="Confirm Discharge"
         message="Are you sure you want to mark this collateral as discharged?"
         confirmLabel="Yes, Discharge"
         variant="danger"

--- a/frontend/src/components/hire-purchase/HirePurchaseForm.tsx
+++ b/frontend/src/components/hire-purchase/HirePurchaseForm.tsx
@@ -17,6 +17,7 @@ import AutocompleteInput from '@/components/shared/AutocompleteInput';
 import { individualsApi } from '@/api/individualsApi';
 import { companiesApi } from '@/api/companiesApi';
 import { Button } from '@/components/ui/button';
+import { ConfirmDialog } from '@/components/shared/ConfirmDialog';
 import { FormSectionHeader } from '@/components/shared/FormSectionHeader';
 import { FieldError } from '@/components/shared/FieldError';
 import { commonApi } from '@/api/commonApi';
@@ -87,6 +88,10 @@ interface HirePurchaseFormProps {
   onCancel: () => void;
   isEdit?: boolean;
   recordId?: number;
+  /** Edit mode only: invoked when "Close" is clicked, to confirm closure of the record. */
+  onCloseRecord?: () => void;
+  /** Edit mode only: loading state for the closure action. */
+  closurePending?: boolean;
 }
 
 export function HirePurchaseForm({
@@ -100,6 +105,8 @@ export function HirePurchaseForm({
   onCancel,
   isEdit,
   recordId,
+  onCloseRecord,
+  closurePending,
 }: HirePurchaseFormProps) {
   const user = useAuthStore((s) => s.user);
   const setUser = useAuthStore((s) => s.setUser);
@@ -125,10 +132,13 @@ export function HirePurchaseForm({
     purchaserDisplayLabel ?? '',
   );
   const isFirstPurchaserTypeRender = useRef(true);
-  const [dataSourceUserId, setDataSourceUserId] = useState<number | undefined>();
+  const [dataSourceUserId, setDataSourceUserId] = useState<
+    number | undefined
+  >();
   const [staffDataSourceName, setStaffDataSourceName] = useState('');
   const [staffDataSourcePosition, setStaffDataSourcePosition] = useState('');
-  const [staffDataSourceSearchLabel, setStaffDataSourceSearchLabel] = useState('');
+  const [staffDataSourceSearchLabel, setStaffDataSourceSearchLabel] =
+    useState('');
 
   const clearDataSource = () => {
     setDataSourceUserId(undefined);
@@ -140,7 +150,7 @@ export function HirePurchaseForm({
   const { register, control, handleSubmit, watch, reset, setValue, setError } =
     useForm<FormValues>({
       resolver: zodResolver(formSchema),
-      mode: 'onSubmit',
+      mode: 'onBlur',
       reValidateMode: 'onChange',
       shouldFocusError: true,
       defaultValues: {
@@ -217,8 +227,9 @@ export function HirePurchaseForm({
   useEffect(() => {
     if (!currentPurchaserType && partyTypeOptions.length > 0) {
       const defaultPurchaser =
-        partyTypeOptions.find((p: { value: string }) => p.value === 'individual') ||
-        partyTypeOptions[0];
+        partyTypeOptions.find(
+          (p: { value: string }) => p.value === 'individual',
+        ) || partyTypeOptions[0];
       setValue('purchaser_type', defaultPurchaser.value, {
         shouldValidate: true,
       });
@@ -227,7 +238,10 @@ export function HirePurchaseForm({
 
   useEffect(() => {
     if (isStaff || user?.client_id) return;
-    void authApi.me().then(setUser).catch(() => {});
+    void authApi
+      .me()
+      .then(setUser)
+      .catch(() => {});
   }, [isStaff, user?.client_id, setUser]);
 
   useEffect(() => {
@@ -256,7 +270,12 @@ export function HirePurchaseForm({
   }, [selectedFinancierId, isEdit, isClientUser]);
 
   useEffect(() => {
-    if (isEdit || !isStaff || financierClientType !== 'individual' || !clientDetail) {
+    if (
+      isEdit ||
+      !isStaff ||
+      financierClientType !== 'individual' ||
+      !clientDetail
+    ) {
       return;
     }
     const details = clientDetail.client_details;
@@ -306,14 +325,24 @@ export function HirePurchaseForm({
 
   const watchAssetType = watch('asset_type');
   const isVehicle = watchAssetType === 'vehicles';
+  const computedBalance =
+    (watch('purchase_amount') ?? 0) - (watch('total_paid_to_date') ?? 0);
+
+  const [confirmingUpdate, setConfirmingUpdate] = useState(false);
+  const [pendingSubmit, setPendingSubmit] = useState<FormValues | null>(null);
 
   const { mutate: submit, isPending } = useMutation({
     mutationFn: (data: FormValues) =>
       isEdit && recordId
         ? hirePurchaseApi.updateRecord(recordId, data as any)
         : hirePurchaseApi.createRecord(data as any),
-    onSuccess,
+    onSuccess: () => {
+      setConfirmingUpdate(false);
+      setPendingSubmit(null);
+      onSuccess();
+    },
     onError: (err: unknown) => {
+      setConfirmingUpdate(false);
       if (!applyApiValidationErrors(setError, err)) {
         const data = (
           err as { response?: { data?: { message?: string; error?: string } } }
@@ -335,18 +364,37 @@ export function HirePurchaseForm({
         ? ({ ...data, financier_id: clientFinancierId } as StaffFormValues)
         : (data as StaffFormValues);
 
+    const withBalance = {
+      ...payload,
+      balance: (data.purchase_amount ?? 0) - (data.total_paid_to_date ?? 0),
+    };
+
     if (isStaff && !isEdit && dataSourceUserId) {
-      return { ...payload, data_source_user_id: dataSourceUserId };
+      return { ...withBalance, data_source_user_id: dataSourceUserId };
     }
-    return payload;
+    return withBalance;
+  };
+
+  const performSubmit = (
+    data: FormValues,
+    options?: Parameters<typeof submit>[1],
+  ) => {
+    submit(buildSubmitPayload(data) as any, options);
   };
 
   const validateStaffDataSource = () => {
-    if (!isStaff || isEdit || !selectedFinancierId || Number(selectedFinancierId) <= 0) {
+    if (
+      !isStaff ||
+      isEdit ||
+      !selectedFinancierId ||
+      Number(selectedFinancierId) <= 0
+    ) {
       return true;
     }
     if (financierClientType === 'company' && !dataSourceUserId) {
-      toast.error('Please select a data source user for this company financier.');
+      toast.error(
+        'Please select a data source user for this company financier.',
+      );
       return false;
     }
     return true;
@@ -362,8 +410,19 @@ export function HirePurchaseForm({
       }
     }
     if (!validateStaffDataSource()) return;
-    submit(buildSubmitPayload(data) as any);
+    if (isEdit) {
+      setPendingSubmit(data);
+      setConfirmingUpdate(true);
+      return;
+    }
+    performSubmit(data);
   }, onInvalid);
+
+  const handleConfirmUpdate = () => {
+    if (pendingSubmit) {
+      performSubmit(pendingSubmit);
+    }
+  };
 
   const handleSaveAndAdd = handleSubmit((data) => {
     if (isClientUser && !isEdit && !clientFinancierId) {
@@ -374,7 +433,7 @@ export function HirePurchaseForm({
     }
     if (!validateStaffDataSource()) return;
 
-    submit(buildSubmitPayload(data) as any, {
+    performSubmit(data, {
       onSuccess: () => {
         reset();
         clearDataSource();
@@ -447,7 +506,10 @@ export function HirePurchaseForm({
                 />
               </div>
               <div className="col-span-2">
-                <ReadOnlyField label="Position" value={editDataSourcePosition} />
+                <ReadOnlyField
+                  label="Position"
+                  value={editDataSourcePosition}
+                />
               </div>
             </div>
           </>
@@ -518,11 +580,13 @@ export function HirePurchaseForm({
                   {partyTypeOptions.length === 0 ? (
                     <option value="company">Loading...</option>
                   ) : (
-                    partyTypeOptions.map((option: { value: string; label: string }) => (
-                      <option key={option.value} value={option.value}>
-                        {option.label}
-                      </option>
-                    ))
+                    partyTypeOptions.map(
+                      (option: { value: string; label: string }) => (
+                        <option key={option.value} value={option.value}>
+                          {option.label}
+                        </option>
+                      ),
+                    )
                   )}
                 </select>
               </div>
@@ -582,7 +646,8 @@ export function HirePurchaseForm({
                           .filter(
                             (u) =>
                               u.name.toLowerCase().includes(term) ||
-                              (u.position?.toLowerCase().includes(term) ?? false),
+                              (u.position?.toLowerCase().includes(term) ??
+                                false),
                           )
                           .map((u) => ({
                             id: u.id,
@@ -650,11 +715,13 @@ export function HirePurchaseForm({
                         ? 'Select type...'
                         : 'Loading types...'}
                     </option>
-                    {partyTypeOptions.map((option: { value: string; label: string }) => (
-                      <option key={option.value} value={option.value}>
-                        {option.label}
-                      </option>
-                    ))}
+                    {partyTypeOptions.map(
+                      (option: { value: string; label: string }) => (
+                        <option key={option.value} value={option.value}>
+                          {option.label}
+                        </option>
+                      ),
+                    )}
                   </select>
                 </div>
               </div>
@@ -746,11 +813,13 @@ export function HirePurchaseForm({
               <option value="">
                 {assetConditionOptions.length ? 'Select...' : 'Loading...'}
               </option>
-              {assetConditionOptions.map((c: { value: string; label: string }) => (
-                <option key={c.value} value={c.value}>
-                  {c.label}
-                </option>
-              ))}
+              {assetConditionOptions.map(
+                (c: { value: string; label: string }) => (
+                  <option key={c.value} value={c.value}>
+                    {c.label}
+                  </option>
+                ),
+              )}
             </select>
           </div>
           <Input label="Serial Number" {...register('reg_serial_number')} />
@@ -809,12 +878,14 @@ export function HirePurchaseForm({
             step="0.01"
             {...register('total_paid_to_date')}
           />
-          <Input
-            label="Balance"
-            type="number"
-            step="0.01"
-            {...register('balance')}
-          />
+          <div>
+            <label className="text-xs font-medium text-slate-600">
+              Balance
+            </label>
+            <div className="mt-1 flex h-8 w-full items-center rounded border border-slate-200 bg-slate-50 px-2 text-sm text-slate-700">
+              {computedBalance.toFixed(2)}
+            </div>
+          </div>
           <Controller
             name="start_date"
             control={control}
@@ -847,24 +918,42 @@ export function HirePurchaseForm({
 
         {/* ── Footer ── */}
         <div className="flex items-center justify-between border-t border-slate-200 bg-slate-50 px-4 py-3">
-          {!isEdit && (
-            <Button
-              type="button"
-              variant="primary"
-              loading={isPending}
-              onClick={handleSaveAndAdd}
-            >
-              + Save And Add
-            </Button>
+          {isEdit ? (
+            <>
+              <Button type="submit" variant="secondary" loading={isPending}>
+                Update
+              </Button>
+              <Button
+                type="button"
+                variant="danger"
+                loading={closurePending}
+                onClick={onCloseRecord}
+              >
+                Close
+              </Button>
+            </>
+          ) : (
+            <>
+              {!isEdit && (
+                <Button
+                  type="button"
+                  variant="primary"
+                  loading={isPending}
+                  onClick={handleSaveAndAdd}
+                >
+                  + Save And Add
+                </Button>
+              )}
+              <div className="flex gap-2 ml-auto">
+                <Button type="button" variant="ghost" onClick={onCancel}>
+                  Cancel
+                </Button>
+                <Button type="submit" variant="secondary" loading={isPending}>
+                  Save And Exit
+                </Button>
+              </div>
+            </>
           )}
-          <div className="flex gap-2 ml-auto">
-            <Button type="button" variant="ghost" onClick={onCancel}>
-              Cancel
-            </Button>
-            <Button type="submit" variant="secondary" loading={isPending}>
-              {isEdit ? 'Save Changes' : 'Save And Exit'}
-            </Button>
-          </div>
         </div>
       </form>
 
@@ -904,6 +993,20 @@ export function HirePurchaseForm({
           }}
         />
       </Modal>
+
+      <ConfirmDialog
+        open={confirmingUpdate}
+        title="Confirm Update"
+        message="Are you sure you want to save these changes?"
+        confirmLabel="Yes, Update"
+        variant="primary"
+        loading={isPending}
+        onConfirm={handleConfirmUpdate}
+        onCancel={() => {
+          setConfirmingUpdate(false);
+          setPendingSubmit(null);
+        }}
+      />
     </>
   );
 }

--- a/frontend/src/components/hire-purchase/HirePurchaseForm.tsx
+++ b/frontend/src/components/hire-purchase/HirePurchaseForm.tsx
@@ -434,6 +434,7 @@ export function HirePurchaseForm({
                     onBlur={field.onBlur}
                     error={fieldState.error?.message}
                     required
+                    disabled
                   />
                 )}
               />
@@ -480,6 +481,7 @@ export function HirePurchaseForm({
                     onBlur={field.onBlur}
                     error={fieldState.error?.message}
                     required
+                    disabled
                   />
                 )}
               />
@@ -558,6 +560,7 @@ export function HirePurchaseForm({
                     onBlur={field.onBlur}
                     error={fieldState.error?.message}
                     required
+                    disabled
                   />
                 )}
               />

--- a/frontend/src/components/hire-purchase/HirePurchaseViewModal.tsx
+++ b/frontend/src/components/hire-purchase/HirePurchaseViewModal.tsx
@@ -1,13 +1,13 @@
 import { useState } from 'react';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { Modal } from '@/components/shared/Modal';
+import { ConfirmDialog } from '@/components/shared/ConfirmDialog';
 import { HirePurchaseForm } from './HirePurchaseForm';
 import type { HirePurchaseRecord } from '@/types';
 import { formatCurrency, formatDate } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
-import { Edit, CheckCircle } from 'lucide-react';
-import { DeleteRecordButton } from '@/components/shared/DeleteRecordButton';
+import { Edit } from 'lucide-react';
 import { hirePurchaseApi } from '@/api/hirePurchaseApi';
 import { invalidateRegistryQueries } from '@/lib/registryCache';
 
@@ -15,23 +15,30 @@ interface HirePurchaseViewModalProps {
   record: HirePurchaseRecord;
   onClose: () => void;
   onSaved: () => void;
-  onDeleted: () => void;
 }
 
 export function HirePurchaseViewModal({
   record,
   onClose,
   onSaved,
-  onDeleted,
 }: HirePurchaseViewModalProps) {
   const [editMode, setEditMode] = useState(false);
   const [confirmingClosure, setConfirmingClosure] = useState(false);
   const queryClient = useQueryClient();
 
+  const { data: detail } = useQuery({
+    queryKey: ['hire-purchase-detail', record.id],
+    queryFn: () => hirePurchaseApi.getRecord(record.id),
+    staleTime: 5 * 60 * 1000,
+  });
+
   const { mutate: confirmClosure, isPending: isConfirming } = useMutation({
     mutationFn: () => hirePurchaseApi.confirmClosure(record.id),
     onSuccess: () => {
       toast.success('Hire purchase closure confirmed');
+      queryClient.invalidateQueries({
+        queryKey: ['hire-purchase-detail', record.id],
+      });
       invalidateRegistryQueries(queryClient, 'hp');
       setConfirmingClosure(false);
       onSaved();
@@ -43,118 +50,104 @@ export function HirePurchaseViewModal({
   });
 
   return (
-    <Modal
-      open
-      onClose={onClose}
-      title={`Hire Purchase — ${record.agreement_number}`}
-      size="xl"
-    >
-      {editMode ? (
-        <HirePurchaseForm
-          isEdit
-          recordId={record.id}
-          financierDisplayLabel={record.financier_name}
-          purchaserDisplayLabel={record.purchaser_name}
-          dataSourceDisplayLabel={record.data_source_display}
-          dataSourcePositionLabel={record.data_source_position}
-          initial={{
-            financier_id: record.financier_id,
-            data_date: record.data_date,
-            purchaser_type: record.purchaser_type,
-            purchaser_id: record.purchaser_id,
-            agreement_number: record.agreement_number,
-            asset_type: record.asset_type,
-            asset_make: record.asset_make,
-            asset_model: record.asset_model,
-            asset_year: record.asset_year,
-            asset_condition: record.asset_condition,
-            reg_serial_number: record.reg_serial_number,
-            chassis_number: record.chassis_number,
-            engine_number: record.engine_number,
-            currency: record.currency,
-            purchase_amount: record.purchase_amount,
-            instalment_amount: record.instalment_amount,
-            instalment_date: record.instalment_date,
-            total_paid_to_date: record.total_paid_to_date,
-            balance: record.balance,
-            start_date: record.start_date,
-            end_date: record.end_date,
-          }}
-          onSuccess={onSaved}
-          onCancel={() => setEditMode(false)}
-        />
-      ) : (
-        <div className="p-5 space-y-4 bg-white">
-          <div className="grid grid-cols-2 gap-x-8 gap-y-3 text-sm sm:grid-cols-3">
-            {[
-              ['Financier', record.financier_name],
-              ['Purchaser', record.purchaser_name],
-              ['Agreement No.', record.agreement_number],
-              ['Asset', `${record.asset_make} ${record.asset_model}`],
-              ['Asset Type', record.asset_type],
-              ['Reg/Serial', record.reg_serial_number],
-              ['Currency', record.currency],
-              ['Purchase Amount', formatCurrency(record.purchase_amount)],
-              ['Instalment', formatCurrency(record.instalment_amount)],
-              ['Balance', formatCurrency(record.balance)],
-              ['Start Date', formatDate(record.start_date)],
-              ['End Date', formatDate(record.end_date)],
-              ['Status', record.status],
-            ].map(([k, v]) => (
-              <div key={String(k)}>
-                <dt className="text-xs font-medium uppercase text-slate-400">
-                  {k}
-                </dt>
-                <dd className="mt-0.5 font-medium text-slate-800">
-                  {String(v)}
-                </dd>
-              </div>
-            ))}
-          </div>
-          <div className="flex flex-wrap items-center justify-between gap-2 pt-2 border-t border-slate-100">
-            <DeleteRecordButton
-              onDelete={() => hirePurchaseApi.deleteRecord(record.id)}
-              onDeleted={onDeleted}
+    <>
+      <Modal
+        open
+        onClose={onClose}
+        title={`Hire Purchase — ${record.agreement_number}`}
+        size="xl"
+      >
+        {editMode ? (
+          detail ? (
+            <HirePurchaseForm
+              isEdit
+              recordId={record.id}
+              financierDisplayLabel={detail.financier_name}
+              purchaserDisplayLabel={detail.purchaser_name}
+              dataSourceDisplayLabel={detail.data_source_display}
+              dataSourcePositionLabel={detail.data_source_position}
+              initial={{
+                financier_id: detail.financier_id,
+                data_date: detail.data_date,
+                purchaser_type: detail.purchaser_type,
+                purchaser_id: detail.purchaser_id,
+                agreement_number: detail.agreement_number,
+                asset_type: detail.asset_type,
+                asset_make: detail.asset_make,
+                asset_model: detail.asset_model,
+                asset_year: detail.asset_year,
+                asset_condition: detail.asset_condition,
+                reg_serial_number: detail.reg_serial_number,
+                chassis_number: detail.chassis_number,
+                engine_number: detail.engine_number,
+                currency: detail.currency,
+                purchase_amount: detail.purchase_amount,
+                instalment_amount: detail.instalment_amount,
+                instalment_date: detail.instalment_date,
+                total_paid_to_date: detail.total_paid_to_date,
+                balance: detail.balance,
+                start_date: detail.start_date,
+                end_date: detail.end_date,
+              }}
+              onSuccess={onSaved}
+              onCancel={() => setEditMode(false)}
+              onCloseRecord={() => setConfirmingClosure(true)}
+              closurePending={isConfirming}
             />
-            <div className="flex gap-2 items-center">
-              {record.status !== 'closed' &&
-                (confirmingClosure ? (
-                  <>
-                    <span className="text-xs text-amber-700">
-                      Confirm closure?
-                    </span>
-                    <Button
-                      type="button"
-                      size="sm"
-                      variant="primary"
-                      loading={isConfirming}
-                      onClick={() => confirmClosure()}
-                    >
-                      Yes, Confirm
-                    </Button>
-                    <Button
-                      type="button"
-                      size="sm"
-                      variant="ghost"
-                      onClick={() => setConfirmingClosure(false)}
-                    >
-                      Cancel
-                    </Button>
-                  </>
-                ) : (
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="secondary"
-                    leftIcon={<CheckCircle className="h-3.5 w-3.5" />}
-                    onClick={() => setConfirmingClosure(true)}
-                  >
-                    Confirm Closure
-                  </Button>
-                ))}
-              <Button variant="ghost" onClick={onClose}>
-                Close
-              </Button>
+          ) : (
+            <div className="flex items-center justify-center p-10 text-sm text-slate-400">
+              Loading…
+            </div>
+          )
+        ) : (
+          <div className="p-5 space-y-4 bg-white">
+            <div className="grid grid-cols-2 gap-x-8 gap-y-3 text-sm sm:grid-cols-3">
+              {[
+                ['Financier', detail?.financier_name ?? record.financier_name],
+                ['Purchaser', detail?.purchaser_name ?? record.purchaser_name],
+                ['Agreement No.', record.agreement_number],
+                [
+                  'Asset',
+                  `${detail?.asset_make ?? ''} ${detail?.asset_model ?? ''}`.trim() ||
+                    record.asset_description,
+                ],
+                ['Asset Type', detail?.asset_type ?? record.asset_type],
+                [
+                  'Reg/Serial',
+                  detail?.reg_serial_number || record.reg_serial_number,
+                ],
+                ['Currency', detail?.currency ?? record.currency],
+                [
+                  'Purchase Amount',
+                  formatCurrency(
+                    detail?.purchase_amount ?? record.purchase_amount,
+                  ),
+                ],
+                [
+                  'Instalment',
+                  formatCurrency(
+                    detail?.instalment_amount ?? record.instalment_amount,
+                  ),
+                ],
+                ['Balance', formatCurrency(detail?.balance ?? record.balance)],
+                [
+                  'Start Date',
+                  formatDate(detail?.start_date ?? record.start_date),
+                ],
+                ['End Date', formatDate(detail?.end_date ?? record.end_date)],
+                ['Status', detail?.status ?? record.status],
+              ].map(([k, v]) => (
+                <div key={String(k)}>
+                  <dt className="text-xs font-medium uppercase text-slate-400">
+                    {k}
+                  </dt>
+                  <dd className="mt-0.5 font-medium text-slate-800">
+                    {String(v ?? '—')}
+                  </dd>
+                </div>
+              ))}
+            </div>
+            <div className="flex items-center justify-end gap-2 pt-2 border-t border-slate-100">
               <Button
                 leftIcon={<Edit className="h-3.5 w-3.5" />}
                 onClick={() => setEditMode(true)}
@@ -163,8 +156,19 @@ export function HirePurchaseViewModal({
               </Button>
             </div>
           </div>
-        </div>
-      )}
-    </Modal>
+        )}
+      </Modal>
+
+      <ConfirmDialog
+        open={confirmingClosure}
+        title="Close Hire Purchase Agreement"
+        message="Are you sure you want to close this hire purchase agreement?"
+        confirmLabel="Yes, Confirm"
+        variant="danger"
+        loading={isConfirming}
+        onConfirm={() => confirmClosure()}
+        onCancel={() => setConfirmingClosure(false)}
+      />
+    </>
   );
 }

--- a/frontend/src/components/layout/SidebarUserMenu.tsx
+++ b/frontend/src/components/layout/SidebarUserMenu.tsx
@@ -1,8 +1,14 @@
-import { useEffect, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
+import { createPortal } from 'react-dom';
 import { LogOut, UserCircle } from 'lucide-react';
 import { useAuth } from '@/hooks/useAuth';
 import { useAuthStore } from '@/store';
-import { cn } from '@/lib/utils';
 import {
   SidebarMenu,
   SidebarMenuButton,
@@ -10,25 +16,127 @@ import {
   useSidebar,
 } from '@/components/ui/sidebar';
 
+type MenuPosition = {
+  top: number;
+  left: number;
+  transform: string;
+};
+
 export function SidebarUserMenu() {
   const { user } = useAuthStore();
   const { logout } = useAuth();
   const { state, isMobile } = useSidebar();
   const [open, setOpen] = useState(false);
+  const [menuPosition, setMenuPosition] = useState<MenuPosition | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
   const collapsed = state === 'collapsed' && !isMobile;
 
   const displayName = user?.name || user?.username || 'User';
 
+  const updateMenuPosition = useCallback(() => {
+    const el = containerRef.current;
+    if (!el) {
+      return;
+    }
+
+    const rect = el.getBoundingClientRect();
+    setMenuPosition(
+      collapsed
+        ? {
+            // Match original collapsed placement: to the right, bottom-aligned.
+            top: rect.bottom,
+            left: rect.right + 8,
+            transform: 'translateY(-100%)',
+          }
+        : {
+            top: rect.top - 8,
+            left: rect.left,
+            transform: 'translateY(-100%)',
+          },
+    );
+  }, [collapsed]);
+
+  useLayoutEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    updateMenuPosition();
+    window.addEventListener('resize', updateMenuPosition);
+    window.addEventListener('scroll', updateMenuPosition, true);
+
+    return () => {
+      window.removeEventListener('resize', updateMenuPosition);
+      window.removeEventListener('scroll', updateMenuPosition, true);
+    };
+  }, [open, updateMenuPosition]);
+
+  useEffect(() => {
+    if (!open) {
+      setMenuPosition(null);
+    }
+  }, [open]);
+
   useEffect(() => {
     function onDocClick(e: MouseEvent) {
-      if (!containerRef.current?.contains(e.target as Node)) {
-        setOpen(false);
+      const target = e.target as Node;
+      if (
+        containerRef.current?.contains(target) ||
+        menuRef.current?.contains(target)
+      ) {
+        return;
       }
+      setOpen(false);
     }
+
     document.addEventListener('mousedown', onDocClick);
     return () => document.removeEventListener('mousedown', onDocClick);
   }, []);
+
+  const handleToggle = () => {
+    setOpen((v) => !v);
+  };
+
+  const menu =
+    open && menuPosition
+      ? createPortal(
+          <div
+            ref={menuRef}
+            role="menu"
+            className="fixed z-[200] min-w-[220px] border border-[#8f8f8f] bg-white py-2 shadow-lg"
+            style={{
+              top: menuPosition.top,
+              left: menuPosition.left,
+              transform: menuPosition.transform,
+            }}
+          >
+            <div className="border-b border-slate-200 px-4 py-3">
+              <p className="text-sm font-semibold text-slate-900">
+                {displayName}
+              </p>
+              {user?.email ? (
+                <p className="mt-0.5 truncate text-xs text-slate-500">
+                  {user.email}
+                </p>
+              ) : null}
+            </div>
+            <button
+              type="button"
+              role="menuitem"
+              className="flex w-full cursor-pointer items-center gap-2 px-4 py-2.5 text-sm font-medium text-[#c62828] hover:bg-red-100"
+              onClick={async () => {
+                setOpen(false);
+                await logout();
+              }}
+            >
+              <LogOut className="h-4 w-4" />
+              Logout
+            </button>
+          </div>,
+          document.body,
+        )
+      : null;
 
   return (
     <SidebarMenu>
@@ -38,7 +146,7 @@ export function SidebarUserMenu() {
             type="button"
             size="lg"
             tooltip={displayName}
-            onClick={() => setOpen((v) => !v)}
+            onClick={handleToggle}
             aria-expanded={open}
             aria-haspopup="menu"
             className="group-data-[collapsible=icon]:justify-center"
@@ -50,41 +158,7 @@ export function SidebarUserMenu() {
               {displayName}
             </span>
           </SidebarMenuButton>
-
-          {open ? (
-            <div
-              role="menu"
-              className={cn(
-                'absolute z-50 min-w-[220px] border border-[#8f8f8f] bg-white py-2 shadow-lg',
-                collapsed
-                  ? 'bottom-0 left-full ml-2'
-                  : 'bottom-full left-0 mb-2',
-              )}
-            >
-              <div className="border-b border-slate-200 px-4 py-3">
-                <p className="text-sm font-semibold text-slate-900">
-                  {displayName}
-                </p>
-                {user?.email ? (
-                  <p className="mt-0.5 truncate text-xs text-slate-500">
-                    {user.email}
-                  </p>
-                ) : null}
-              </div>
-              <button
-                type="button"
-                role="menuitem"
-                className="flex w-full items-center gap-2 px-4 py-2.5 text-sm font-medium text-slate-800 hover:bg-slate-50"
-                onClick={async () => {
-                  setOpen(false);
-                  await logout();
-                }}
-              >
-                <LogOut className="h-4 w-4" />
-                Logout
-              </button>
-            </div>
-          ) : null}
+          {menu}
         </div>
       </SidebarMenuItem>
     </SidebarMenu>

--- a/frontend/src/components/registry/AssetRegistryForm.tsx
+++ b/frontend/src/components/registry/AssetRegistryForm.tsx
@@ -68,7 +68,7 @@ export function AssetRegistryForm({
   const { register, control, handleSubmit, watch, setValue, setError } =
     useForm<FormValues>({
       resolver: zodResolver(schema),
-      mode: 'onSubmit',
+      mode: 'onBlur',
       reValidateMode: 'onChange',
       shouldFocusError: true,
       defaultValues: {

--- a/frontend/src/components/shared/ConfirmDialog.tsx
+++ b/frontend/src/components/shared/ConfirmDialog.tsx
@@ -1,0 +1,68 @@
+import { Modal } from './Modal';
+import { Button } from '@/components/ui/button';
+
+interface ConfirmDialogProps {
+  open: boolean;
+  title?: string;
+  message: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  variant?: 'danger' | 'primary' | 'secondary' | 'success';
+  loading?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+/**
+ * App-styled replacement for the browser's native `window.confirm()`, so
+ * confirmation prompts match the rest of the UI instead of looking like a
+ * stock OS alert box.
+ *
+ * Render as a sibling of other modals (not nested inside them) so the
+ * backdrop and z-index behave correctly.
+ */
+export function ConfirmDialog({
+  open,
+  title = 'Please Confirm',
+  message,
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+  variant = 'danger',
+  loading = false,
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  if (!open) return null;
+
+  return (
+    <Modal
+      open={open}
+      onClose={loading ? () => {} : onCancel}
+      title={title}
+      size="sm"
+      disableBackdropClose
+    >
+      <div className="space-y-4 bg-white p-5">
+        <p className="text-sm leading-relaxed text-slate-700">{message}</p>
+        <div className="flex items-center justify-end gap-2 border-t border-slate-200 pt-3">
+          <Button
+            type="button"
+            variant="ghost"
+            disabled={loading}
+            onClick={onCancel}
+          >
+            {cancelLabel}
+          </Button>
+          <Button
+            type="button"
+            variant={variant}
+            loading={loading}
+            onClick={onConfirm}
+          >
+            {confirmLabel}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/pages/AssetRegistryPage.tsx
+++ b/frontend/src/pages/AssetRegistryPage.tsx
@@ -1,7 +1,14 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
-import { ArrowDown, ArrowUp, ArrowUpDown, Plus, Search } from 'lucide-react';
+import {
+  ArrowDown,
+  ArrowUp,
+  ArrowUpDown,
+  Layers,
+  Plus,
+  Search,
+} from 'lucide-react';
 import { assetRegistryApi } from '@/api/assetRegistryApi';
 import { commonApi } from '@/api/commonApi';
 import { queryOptions } from '@/api/queryOptions';
@@ -29,7 +36,10 @@ export default function AssetRegistryPage() {
   const [sortOption, setSortOption] = useState<AssetSortOption>('date-desc');
   const [currentPage, setCurrentPage] = useState(1);
   const [addOpen, setAddOpen] = useState(false);
+  const [addMultipleOpen, setAddMultipleOpen] = useState(false);
+  const [uploadFile, setUploadFile] = useState<File | null>(null);
   const [viewRecord, setViewRecord] = useState<AssetRecord | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const { data: choices = {} } = useQuery({
     queryKey: ['common-choices'],
@@ -192,15 +202,42 @@ export default function AssetRegistryPage() {
             </Button>
           </div>
 
-          <Button
-            size="sm"
-            variant="success"
-            leftIcon={<Plus className="h-3.5 w-3.5" />}
-            onClick={() => setAddOpen(true)}
-            className="h-7 rounded-none px-3 text-[12px] font-bold"
-          >
-            Add Single
-          </Button>
+          <div className="flex gap-1">
+            <Button
+              size="sm"
+              variant="success"
+              leftIcon={<Plus className="h-3.5 w-3.5" />}
+              onClick={() => setAddOpen(true)}
+              className="h-7 rounded-none px-3 text-[12px] font-bold"
+            >
+              Add Single
+            </Button>
+            <Button
+              size="sm"
+              variant="secondary"
+              leftIcon={<Layers className="h-3.5 w-3.5" />}
+              onClick={() => fileInputRef.current?.click()}
+              className="h-7 rounded-none px-3 text-[12px] font-bold"
+            >
+              Add Multiple
+            </Button>
+            {/* Hidden file input — CSV / Excel only */}
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".csv,.xlsx,.xls,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-excel,text/csv"
+              className="hidden"
+              onChange={(e) => {
+                const file = e.target.files?.[0] ?? null;
+                if (file) {
+                  setUploadFile(file);
+                  setAddMultipleOpen(true);
+                }
+                // reset so the same file can be re-selected if needed
+                e.target.value = '';
+              }}
+            />
+          </div>
         </div>
 
         <div className="shrink-0 bg-[#7f7a7b] px-3 py-1 text-center text-[14px] font-bold uppercase text-white">
@@ -232,7 +269,7 @@ export default function AssetRegistryPage() {
                     </button>
                   </th>
                   <th className="px-2 py-2 font-bold text-black">
-                    Regist. No.
+                    Registor. No.
                   </th>
                   <th className="px-2 py-2 font-bold text-black">
                     <button
@@ -253,12 +290,14 @@ export default function AssetRegistryPage() {
                     </button>
                   </th>
                   <th className="px-2 py-2 font-bold text-black">
-                    Description
+                    Asset Description
                   </th>
-                  <th className="px-2 py-2 font-bold text-black">Reg/Serial</th>
+                  <th className="px-2 py-2 font-bold text-black">
+                    Reg/Serial Number
+                  </th>
                   <th className="px-2 py-2 font-bold text-black">Currency</th>
                   <th className="px-2 py-2 font-bold text-black text-right">
-                    Est. Value
+                    Estimate Value
                   </th>
                   <th className="px-2 py-2 font-bold text-black">
                     Sub. Start Date
@@ -354,6 +393,45 @@ export default function AssetRegistryPage() {
           }}
           onCancel={() => setAddOpen(false)}
         />
+      </Modal>
+
+      <Modal
+        open={addMultipleOpen}
+        onClose={() => {
+          setAddMultipleOpen(false);
+          setUploadFile(null);
+        }}
+        title="Upload Multiple Records"
+        size="sm"
+      >
+        <div className="flex flex-col gap-4 p-6">
+          <div className="flex items-center gap-3 rounded border border-slate-200 bg-slate-50 px-4 py-3">
+            <Layers className="h-5 w-5 shrink-0 text-slate-400" />
+            <div className="min-w-0">
+              <p className="truncate text-sm font-medium text-slate-800">
+                {uploadFile?.name}
+              </p>
+              <p className="text-xs text-slate-500">
+                {uploadFile ? (uploadFile.size / 1024).toFixed(1) + ' KB' : ''}
+              </p>
+            </div>
+          </div>
+          <p className="text-sm text-slate-500">
+            Import functionality coming soon. Your file has been selected and is
+            ready for processing.
+          </p>
+          <div className="flex justify-end gap-2">
+            <Button
+              variant="ghost"
+              onClick={() => {
+                setAddMultipleOpen(false);
+                setUploadFile(null);
+              }}
+            >
+              Close
+            </Button>
+          </div>
+        </div>
       </Modal>
 
       {viewRecord && (

--- a/frontend/src/pages/CollateralPage.tsx
+++ b/frontend/src/pages/CollateralPage.tsx
@@ -135,6 +135,15 @@ export default function CollateralPage() {
     invalidateRegistryQueries(queryClient, 'collateral');
   };
 
+  const handleViewRecord = (rec: CollateralRecord) => {
+    void queryClient.prefetchQuery({
+      queryKey: ['collateral-detail', rec.id],
+      queryFn: () => collateralApi.getRecord(rec.id),
+      staleTime: 5 * 60 * 1000,
+    });
+    setViewRecord(rec);
+  };
+
   const totalRecords = recordsData?.count ?? 0;
   const totalPages = Math.max(1, Math.ceil(totalRecords / PAGE_SIZE));
   const activePage = Math.min(currentPage, totalPages);
@@ -408,7 +417,7 @@ export default function CollateralPage() {
                       <td className="px-2 py-2">
                         <button
                           type="button"
-                          onClick={() => setViewRecord(rec)}
+                          onClick={() => handleViewRecord(rec)}
                           className={cn(
                             'flex items-center gap-1 px-2 py-1 text-[11px] font-bold uppercase text-white',
                             isPendingDischarge(rec)
@@ -498,10 +507,6 @@ export default function CollateralPage() {
           record={viewRecord}
           onClose={() => setViewRecord(null)}
           onSaved={() => {
-            setViewRecord(null);
-            refreshList(false);
-          }}
-          onDeleted={() => {
             setViewRecord(null);
             refreshList(false);
           }}

--- a/frontend/src/pages/CollateralPage.tsx
+++ b/frontend/src/pages/CollateralPage.tsx
@@ -5,6 +5,7 @@ import {
   ArrowDown,
   ArrowUp,
   ArrowUpDown,
+  Eye,
   Layers,
   Plus,
   Search,
@@ -18,7 +19,12 @@ import { Modal } from '@/components/shared/Modal';
 import { CollateralForm } from '@/components/collateral/CollateralForm';
 import { CollateralViewModal } from '@/components/collateral/CollateralViewModal';
 import { NumberedPaginationFooter } from '@/components/shared/NumberedPaginationFooter';
-import { cn, formatCurrency, formatDate, formatDollarAmount } from '@/lib/utils';
+import {
+  cn,
+  formatCurrency,
+  formatDate,
+  formatDollarAmount,
+} from '@/lib/utils';
 import { invalidateRegistryQueries } from '@/lib/registryCache';
 import { registryQueryOptions } from '@/lib/registryQueryOptions';
 import { useAuthStore } from '@/store';
@@ -28,14 +34,51 @@ const PAGE_SIZE = 20;
 
 type CollateralSortOption = 'date-desc' | 'date-asc' | 'name-asc' | 'name-desc';
 
+type CollateralSearchField = 'agreement_number' | 'debtor' | 'reg_serial_number';
+
+const SEARCH_FIELD_OPTIONS: { value: CollateralSearchField; label: string }[] = [
+  { value: 'agreement_number', label: 'Agreement Number' },
+  { value: 'debtor', label: 'Debtor' },
+  { value: 'reg_serial_number', label: 'Reg/Serial Number' },
+];
+
+const SEARCH_FIELD_PLACEHOLDERS: Record<CollateralSearchField, string> = {
+  agreement_number: 'Search by agreement number...',
+  debtor: 'Search by debtor...',
+  reg_serial_number: 'Search by reg/serial number...',
+};
+
+/** Agreement end date has passed (matches backend pending-discharge logic). */
+function isExpired(rec: CollateralRecord): boolean {
+  if (!rec.end_date) {
+    return false;
+  }
+  const end = new Date(rec.end_date);
+  if (Number.isNaN(end.getTime())) {
+    return false;
+  }
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  return end < today;
+}
+
+/** True when a loan's end date has passed and it has not yet been discharged. */
+function isPendingDischarge(rec: CollateralRecord): boolean {
+  return isExpired(rec) && rec.status !== 'discharged';
+}
+
 export default function CollateralPage() {
   const queryClient = useQueryClient();
   const authReady = useAuthStore((s) => s.authReady);
+  const [searchField, setSearchField] =
+    useState<CollateralSearchField>('agreement_number');
   const [searchValue, setSearchValue] = useState('');
   const [sortOption, setSortOption] =
     useState<CollateralSortOption>('date-desc');
   const [currentPage, setCurrentPage] = useState(1);
   const [appliedSearch, setAppliedSearch] = useState('');
+  const [appliedSearchField, setAppliedSearchField] =
+    useState<CollateralSearchField>('agreement_number');
   const [addOpen, setAddOpen] = useState(false);
   const [addMultipleOpen, setAddMultipleOpen] = useState(false);
   const [uploadFile, setUploadFile] = useState<File | null>(null);
@@ -55,10 +98,17 @@ export default function CollateralPage() {
     isError,
     isFetching,
   } = useQuery({
-    queryKey: ['collateral-records', appliedSearch, currentPage],
+    queryKey: [
+      'collateral-records',
+      appliedSearch,
+      appliedSearchField,
+      currentPage,
+    ],
     queryFn: () =>
       collateralApi.getRecords({
-        ...(appliedSearch ? { search: appliedSearch } : {}),
+        ...(appliedSearch
+          ? { search: appliedSearch, search_field: appliedSearchField }
+          : {}),
         page: currentPage,
         page_size: PAGE_SIZE,
       }),
@@ -70,6 +120,7 @@ export default function CollateralPage() {
 
   const handleSearch = () => {
     setAppliedSearch(searchValue.trim());
+    setAppliedSearchField(searchField);
     setCurrentPage(1);
   };
 
@@ -77,6 +128,8 @@ export default function CollateralPage() {
     if (clearFilters) {
       setSearchValue('');
       setAppliedSearch('');
+      setSearchField('agreement_number');
+      setAppliedSearchField('agreement_number');
     }
     setCurrentPage(1);
     invalidateRegistryQueries(queryClient, 'collateral');
@@ -160,11 +213,24 @@ export default function CollateralPage() {
         <div className="flex flex-wrap items-center justify-between gap-2 border-b border-[#8f8f8f] px-3 py-2">
           <div className="flex flex-wrap items-center gap-2">
             <span className="text-[12px] font-bold text-black">Search</span>
+            <select
+              value={searchField}
+              onChange={(e) =>
+                setSearchField(e.target.value as CollateralSearchField)
+              }
+              className="h-7 min-w-[140px] rounded-none border border-black bg-white px-2 text-[12px]"
+            >
+              {SEARCH_FIELD_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
             <input
               value={searchValue}
               onChange={(e) => setSearchValue(e.target.value)}
               onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
-              placeholder="Agreement, debtor, reg..."
+              placeholder={SEARCH_FIELD_PLACEHOLDERS[searchField]}
               className="h-7 w-56 border border-black bg-white px-2 text-[12px] focus:outline-none"
             />
             <Button
@@ -176,6 +242,21 @@ export default function CollateralPage() {
             >
               Search
             </Button>
+            {appliedSearch ? (
+              <button
+                type="button"
+                className="text-[11px] text-[#196A86] underline"
+                onClick={() => {
+                  setSearchValue('');
+                  setAppliedSearch('');
+                  setSearchField('agreement_number');
+                  setAppliedSearchField('agreement_number');
+                  setCurrentPage(1);
+                }}
+              >
+                Clear filter
+              </button>
+            ) : null}
           </div>
 
           <div className="flex gap-1">
@@ -217,7 +298,7 @@ export default function CollateralPage() {
         </div>
 
         <div className="bg-[#7f7a7b] px-3 py-1 text-center text-[14px] font-bold uppercase text-white">
-          Active Debts
+          Active Agreements
         </div>
 
         <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
@@ -244,7 +325,7 @@ export default function CollateralPage() {
                       )}
                     </button>
                   </th>
-                  <th className="px-2 py-2 font-bold">Financier</th>
+                  <th className="px-2 py-2 font-bold">Agreement No.</th>
                   <th className="px-2 py-2 font-bold">
                     <button
                       type="button"
@@ -263,22 +344,23 @@ export default function CollateralPage() {
                       )}
                     </button>
                   </th>
-                  <th className="px-2 py-2 font-bold">Asset</th>
-                  <th className="px-2 py-2 font-bold">Reg/Serial</th>
+                  <th className="px-2 py-2 font-bold">Asset Description</th>
+                  <th className="px-2 py-2 font-bold">Reg/Serial Number</th>
                   <th className="px-2 py-2 font-bold">Currency</th>
-                  <th className="px-2 py-2 font-bold text-right">Loan</th>
-                  <th className="px-2 py-2 font-bold">Start</th>
-                  <th className="px-2 py-2 font-bold">End</th>
-                  <th className="px-2 py-2 font-bold">Status</th>
+                  <th className="px-2 py-2 font-bold text-right">
+                    Loan Amount
+                  </th>
+                  <th className="px-2 py-2 font-bold">Start Date</th>
+                  <th className="px-2 py-2 font-bold">End Date</th>
                   <th className="px-2 py-2 font-bold" />
                 </tr>
               </thead>
               <tbody>
                 {loadingRecords ? (
-                  <TableSkeleton rows={8} cols={12} />
+                  <TableSkeleton rows={8} cols={11} />
                 ) : isError ? (
                   <tr>
-                    <td colSpan={12} className="py-6 text-center text-red-500">
+                    <td colSpan={11} className="py-6 text-center text-red-500">
                       Failed to load records.
                     </td>
                   </tr>
@@ -299,8 +381,8 @@ export default function CollateralPage() {
                       <td className="border-r border-[#8f8f8f] px-2 py-2">
                         {formatDate(rec.lodge_date)}
                       </td>
-                      <td className="border-r border-[#8f8f8f] px-2 py-2 font-bold text-[#196A86]">
-                        {rec.financier_name}
+                      <td className="border-r border-[#8f8f8f] px-2 py-2">
+                        {rec.agreement_number}
                       </td>
                       <td className="border-r border-[#8f8f8f] px-2 py-2">
                         {rec.debtor_name}
@@ -323,28 +405,18 @@ export default function CollateralPage() {
                       <td className="border-r border-[#8f8f8f] px-2 py-2">
                         {formatDate(rec.end_date)}
                       </td>
-                      <td className="border-r border-[#8f8f8f] px-2 py-2">
-                        <span
-                          className={cn(
-                            'inline-block rounded px-1.5 py-0.5 text-[11px] font-semibold uppercase',
-                            rec.status === 'active'
-                              ? 'bg-green-100 text-green-800'
-                              : rec.status === 'pending_discharge'
-                                ? 'bg-amber-100 text-amber-800'
-                                : 'bg-slate-100 text-slate-600',
-                          )}
-                        >
-                          {rec.status === 'pending_discharge'
-                            ? 'Pending'
-                            : rec.status}
-                        </span>
-                      </td>
                       <td className="px-2 py-2">
                         <button
                           type="button"
                           onClick={() => setViewRecord(rec)}
-                          className="bg-[#196A86] px-2 py-1 text-[11px] font-bold text-white hover:bg-[#15586f]"
+                          className={cn(
+                            'flex items-center gap-1 px-2 py-1 text-[11px] font-bold uppercase text-white',
+                            isPendingDischarge(rec)
+                              ? 'bg-[#f97316] hover:bg-[#ea580c]'
+                              : 'bg-[#196A86] hover:bg-[#15586f]',
+                          )}
                         >
+                          <Eye className="h-3 w-3" />
                           View
                         </button>
                       </td>

--- a/frontend/src/pages/HirePurchasePage.tsx
+++ b/frontend/src/pages/HirePurchasePage.tsx
@@ -31,6 +31,20 @@ type HirePurchaseSortOption =
   | 'name-asc'
   | 'name-desc';
 
+type HirePurchaseSearchField = 'agreement_number' | 'purchaser' | 'reg_serial_number';
+
+const SEARCH_FIELD_OPTIONS: { value: HirePurchaseSearchField; label: string }[] = [
+  { value: 'agreement_number', label: 'Agreement Number' },
+  { value: 'purchaser', label: 'Purchaser Name' },
+  { value: 'reg_serial_number', label: 'Reg/Serial Number' },
+];
+
+const SEARCH_FIELD_PLACEHOLDERS: Record<HirePurchaseSearchField, string> = {
+  agreement_number: 'Search by agreement number...',
+  purchaser: 'Search by purchaser name...',
+  reg_serial_number: 'Search by reg/serial number...',
+};
+
 /** Agreement end date has passed (matches backend pending-closure logic). */
 function isExpired(rec: HirePurchaseRecord): boolean {
   if (!rec.end_date) {
@@ -47,8 +61,12 @@ function isExpired(rec: HirePurchaseRecord): boolean {
 
 export default function HirePurchasePage() {
   const queryClient = useQueryClient();
+  const [searchField, setSearchField] =
+    useState<HirePurchaseSearchField>('agreement_number');
   const [searchValue, setSearchValue] = useState('');
   const [appliedSearch, setAppliedSearch] = useState('');
+  const [appliedSearchField, setAppliedSearchField] =
+    useState<HirePurchaseSearchField>('agreement_number');
   const [sortOption, setSortOption] =
     useState<HirePurchaseSortOption>('date-desc');
   const [currentPage, setCurrentPage] = useState(1);
@@ -64,10 +82,12 @@ export default function HirePurchasePage() {
   });
 
   const { data: recordsData, isLoading } = useQuery({
-    queryKey: ['hp-records', appliedSearch, currentPage],
+    queryKey: ['hp-records', appliedSearch, appliedSearchField, currentPage],
     queryFn: () =>
       hirePurchaseApi.getRecords({
-        ...(appliedSearch ? { search: appliedSearch } : {}),
+        ...(appliedSearch
+          ? { search: appliedSearch, search_field: appliedSearchField }
+          : {}),
         page: currentPage,
         page_size: PAGE_SIZE,
       }),
@@ -75,6 +95,7 @@ export default function HirePurchasePage() {
 
   const handleSearch = () => {
     setAppliedSearch(searchValue.trim());
+    setAppliedSearchField(searchField);
     setCurrentPage(1);
   };
 
@@ -82,6 +103,8 @@ export default function HirePurchasePage() {
     if (clearFilters) {
       setSearchValue('');
       setAppliedSearch('');
+      setSearchField('agreement_number');
+      setAppliedSearchField('agreement_number');
     }
     setCurrentPage(1);
     invalidateRegistryQueries(queryClient, 'hp');
@@ -185,11 +208,24 @@ export default function HirePurchasePage() {
         <div className="flex flex-wrap items-center justify-between gap-2 border-b border-[#8f8f8f] px-3 py-2">
           <div className="flex flex-wrap items-center gap-2">
             <span className="text-[12px] font-bold text-black">Search</span>
+            <select
+              value={searchField}
+              onChange={(e) =>
+                setSearchField(e.target.value as HirePurchaseSearchField)
+              }
+              className="h-7 min-w-[140px] rounded-none border border-black bg-white px-2 text-[12px]"
+            >
+              {SEARCH_FIELD_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
             <input
               value={searchValue}
               onChange={(e) => setSearchValue(e.target.value)}
               onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
-              placeholder="Agreement, purchaser, financier, reg..."
+              placeholder={SEARCH_FIELD_PLACEHOLDERS[searchField]}
               className="h-7 w-56 border border-black bg-white px-2 text-[12px] focus:outline-none"
             />
             <Button
@@ -208,6 +244,8 @@ export default function HirePurchasePage() {
                 onClick={() => {
                   setSearchValue('');
                   setAppliedSearch('');
+                  setSearchField('agreement_number');
+                  setAppliedSearchField('agreement_number');
                   setCurrentPage(1);
                 }}
               >

--- a/frontend/src/pages/HirePurchasePage.tsx
+++ b/frontend/src/pages/HirePurchasePage.tsx
@@ -21,6 +21,8 @@ import { HirePurchaseViewModal } from '@/components/hire-purchase/HirePurchaseVi
 import { NumberedPaginationFooter } from '@/components/shared/NumberedPaginationFooter';
 import { cn, formatCurrency, formatDate } from '@/lib/utils';
 import { invalidateRegistryQueries } from '@/lib/registryCache';
+import { registryQueryOptions } from '@/lib/registryQueryOptions';
+import { useAuthStore } from '@/store';
 import type { HirePurchaseRecord } from '@/types';
 
 const PAGE_SIZE = 20;
@@ -61,6 +63,7 @@ function isExpired(rec: HirePurchaseRecord): boolean {
 
 export default function HirePurchasePage() {
   const queryClient = useQueryClient();
+  const authReady = useAuthStore((s) => s.authReady);
   const [searchField, setSearchField] =
     useState<HirePurchaseSearchField>('agreement_number');
   const [searchValue, setSearchValue] = useState('');
@@ -79,9 +82,15 @@ export default function HirePurchasePage() {
   const { data: statsData } = useQuery({
     queryKey: ['hp-dashboard'],
     queryFn: () => hirePurchaseApi.getDashboard(),
+    enabled: authReady,
+    ...registryQueryOptions,
   });
 
-  const { data: recordsData, isLoading } = useQuery({
+  const {
+    data: recordsData,
+    isLoading,
+    isFetching,
+  } = useQuery({
     queryKey: ['hp-records', appliedSearch, appliedSearchField, currentPage],
     queryFn: () =>
       hirePurchaseApi.getRecords({
@@ -91,7 +100,20 @@ export default function HirePurchasePage() {
         page: currentPage,
         page_size: PAGE_SIZE,
       }),
+    enabled: authReady,
+    ...registryQueryOptions,
   });
+
+  const loadingRecords = !authReady || isLoading || isFetching;
+
+  const handleViewRecord = (rec: HirePurchaseRecord) => {
+    void queryClient.prefetchQuery({
+      queryKey: ['hire-purchase-detail', rec.id],
+      queryFn: () => hirePurchaseApi.getRecord(rec.id),
+      staleTime: 5 * 60 * 1000,
+    });
+    setViewRecord(rec);
+  };
 
   const handleSearch = () => {
     setAppliedSearch(searchValue.trim());
@@ -349,7 +371,7 @@ export default function HirePurchasePage() {
                 </tr>
               </thead>
               <tbody>
-                {isLoading ? (
+                {loadingRecords ? (
                   <TableSkeleton rows={8} cols={11} />
                 ) : !sortedRecords.length ? (
                   <EmptyState message="No hire purchase agreements found." />
@@ -375,7 +397,7 @@ export default function HirePurchasePage() {
                         {rec.purchaser_name}
                       </td>
                       <td className="border-r border-[#8f8f8f] px-2 py-2">
-                        {rec.asset_make} {rec.asset_model}
+                        {rec.asset_description}
                       </td>
                       <td className="border-r border-[#8f8f8f] px-2 py-2">
                         {rec.reg_serial_number}
@@ -395,7 +417,7 @@ export default function HirePurchasePage() {
                       <td className="px-2 py-2">
                         <button
                           type="button"
-                          onClick={() => setViewRecord(rec)}
+                          onClick={() => handleViewRecord(rec)}
                           className={cn(
                             'flex items-center gap-1 px-2 py-1 text-[11px] font-bold uppercase text-white',
                             isExpired(rec)
@@ -485,10 +507,6 @@ export default function HirePurchasePage() {
           record={viewRecord}
           onClose={() => setViewRecord(null)}
           onSaved={() => {
-            setViewRecord(null);
-            refreshList(false);
-          }}
-          onDeleted={() => {
             setViewRecord(null);
             refreshList(false);
           }}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -114,6 +114,7 @@ export interface HirePurchaseRecord {
   purchaser_name: string;
   purchaser_type: OwnerType;
   purchaser_id: number;
+  asset_description: string;
   asset_make: string;
   asset_model: string;
   asset_type: string;


### PR DESCRIPTION
## Summary

- Align Collateral and Hire Purchase registry list/stats filtering with role-based client scoping, and exclude closed/discharged records from dashboard views
- Rework view/edit modals with app-styled confirmation dialogs, read-only fields in edit mode, and consistent Update/Close actions
- Fix several frontend regressions on Asset Registry and the sidebar profile menu (missing imports/refs, layout, stacking, logout styling)

## Backend

- Add shared `scope_registry_to_client_portfolio()` helper for consistent client-user filtering by financier
- Filter list endpoints to active records only (`is_discharged=False` for Collateral, `closure_confirmed=False` for HP)
- Add lean `HirePurchaseRegistrationListSerializer` for dashboard/list responses
- Ensure stats endpoints use the same scoping logic as list endpoints

## Frontend — Registry pages

- Add searchable field dropdowns (Agreement Number, Debtor/Purchaser, Reg/Serial) for Collateral and HP
- Color-code View buttons (blue = active, orange = pending discharge/closure)
- Prefetch record detail on View click for faster edit mode
- Use `registryQueryOptions` and cache key bump to fix stale React Query data for client users
- Fix HP balance as read-only computed field in forms and view modals

## Frontend — View/Edit workflow

- View mode: Edit only
- Edit mode: Update (left) + Close (right, danger)
- Add shared `ConfirmDialog` for Update and Close/Discharge actions (replaces `window.confirm`)
- Make financier/debtor/purchaser fields read-only in edit mode
- Disable Data Date editing in create/edit forms
- Switch form validation to `onBlur`

## Frontend — Asset Registry fixes

- Add missing `Layers` icon import
- Add missing bulk-upload state (`fileInputRef`, `uploadFile`, `addMultipleOpen`) and upload modal
- Group Add Single / Add Multiple buttons in `flex gap-1` for consistent spacing

## Frontend — Sidebar / profile menu

- Portal profile dropdown to `document.body` with fixed positioning and higher z-index
- Restore correct collapsed-sidebar placement (opens to the right, bottom-aligned)
- Style Logout as red with pointer cursor on hover

## Test plan

- [ ] Log in as staff and client user; verify Collateral/HP tables match dashboard stats
- [ ] Confirm closed HP and discharged Collateral records do not appear in list views
- [ ] Open View → Edit on Collateral and HP; verify read-only party fields and disabled Data Date
- [ ] Test Update and Close flows; confirm app-styled dialogs appear and actions complete
- [ ] Collapse sidebar; open profile menu and confirm it appears above registry tabs/page content
- [ ] Open Asset Registry; verify page loads, Add Multiple works, and button spacing matches other registries
- [ ] Hard refresh after deploy to clear any stale localStorage React Query cache