### PR TITLE
Fix registry dashboard bugs and improve collateral/HP view-edit workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
 
     env:
       SECRET_KEY: ${{ secrets.SECRET_KEY || 'test-secret-key-for-ci' }}
+      CSRF_TRUSTED_ORIGINS: http://localhost/
       DEBUG: "False"
       DB_ENGINE: django.db.backends.sqlite3
       DB_NAME: /tmp/test.db

--- a/apps/clients/api/views.py
+++ b/apps/clients/api/views.py
@@ -162,7 +162,8 @@ class ClientViewSet(viewsets.ModelViewSet):
     @action(detail=False, methods=['get'], url_path='search')
     def search(self, request):
         """
-        Search for clients by name or external client ID
+        Search for clients by name or external client ID.
+        Optional query param entity_type: individual | company
         """
         query = request.query_params.get('q', '').strip()
         if not query:
@@ -170,11 +171,23 @@ class ClientViewSet(viewsets.ModelViewSet):
                 {"detail": "Query parameter 'q' is required"},
                 status=status.HTTP_400_BAD_REQUEST
             )
-        
+
         clients = Client.objects.filter(
             Q(name__icontains=query) | Q(external_client_id__icontains=query)
-        ).distinct()
-        
+        )
+
+        entity_type = request.query_params.get('entity_type', '').strip().lower()
+        if entity_type == 'individual':
+            clients = clients.filter(
+                client_content_type=ContentType.objects.get_for_model(Individual)
+            )
+        elif entity_type == 'company':
+            clients = clients.filter(
+                client_content_type=ContentType.objects.get_for_model(CompanyBranch)
+            )
+
+        clients = clients.distinct()
+
         serializer = MinimalClientSerializer(clients, many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)
 

--- a/apps/collateral/api/serializers.py
+++ b/apps/collateral/api/serializers.py
@@ -33,6 +33,8 @@ class CollateralRegistrationSerializer(serializers.ModelSerializer):
     is_pending_discharge = serializers.SerializerMethodField(read_only=True)
     financier_display = serializers.SerializerMethodField(read_only=True)
     debtor_display = serializers.SerializerMethodField(read_only=True)
+    data_source_display = serializers.SerializerMethodField(read_only=True)
+    data_source_position = serializers.SerializerMethodField(read_only=True)
     currency = serializers.SlugRelatedField(
         slug_field="code",
         queryset=Currency.objects.all(),
@@ -78,6 +80,8 @@ class CollateralRegistrationSerializer(serializers.ModelSerializer):
             "is_pending_discharge",
             "financier_display",
             "debtor_display",
+            "data_source_display",
+            "data_source_position",
         ]
         read_only_fields = [
             "id",
@@ -106,6 +110,16 @@ class CollateralRegistrationSerializer(serializers.ModelSerializer):
 
     def get_debtor_display(self, obj: CollateralRegistration) -> str:
         return obj.debtor_display
+
+    def get_data_source_display(self, obj: CollateralRegistration) -> str:
+        if obj.created_by is None:
+            return ""
+        return obj.created_by.get_full_name() or obj.created_by.username or ""
+
+    def get_data_source_position(self, obj: CollateralRegistration) -> str:
+        if obj.created_by is None:
+            return ""
+        return obj.created_by.position or ""
 
     # ------------------------------------------------------------------
     # Field-level validation
@@ -249,6 +263,12 @@ class CollateralRegistrationSerializer(serializers.ModelSerializer):
         6. Financier and debtor cannot be the same party.
         7. Active asset/device identifiers must be unique.
         """
+        request = self.context.get("request")
+        if request and request.user.is_authenticated:
+            user = request.user
+            if not user.is_staff and user.client:
+                attrs["financier"] = user.client
+
         # --- 1. Date ordering ---
         start = attrs.get(
             "agreement_start_date",
@@ -430,6 +450,11 @@ class CollateralDashboardSerializer(serializers.Serializer):
 
     active_agreements = serializers.IntegerField(min_value=0)
     pending_discharge_confirmation = serializers.IntegerField(min_value=0)
+    total_active_loan_value = serializers.DecimalField(
+        max_digits=18,
+        decimal_places=2,
+        min_value=0,
+    )
 
 
 class CollateralRegistrationListSerializer(CollateralRegistrationSerializer):

--- a/apps/collateral/api/serializers.py
+++ b/apps/collateral/api/serializers.py
@@ -35,6 +35,7 @@ class CollateralRegistrationSerializer(serializers.ModelSerializer):
     debtor_display = serializers.SerializerMethodField(read_only=True)
     data_source_display = serializers.SerializerMethodField(read_only=True)
     data_source_position = serializers.SerializerMethodField(read_only=True)
+    data_source_user_id = serializers.IntegerField(write_only=True, required=False)
     currency = serializers.SlugRelatedField(
         slug_field="code",
         queryset=Currency.objects.all(),
@@ -82,6 +83,7 @@ class CollateralRegistrationSerializer(serializers.ModelSerializer):
             "debtor_display",
             "data_source_display",
             "data_source_position",
+            "data_source_user_id",
         ]
         read_only_fields = [
             "id",
@@ -386,7 +388,36 @@ class CollateralRegistrationSerializer(serializers.ModelSerializer):
 
     @transaction.atomic
     def create(self, validated_data):
-        validated_data["created_by"] = self.context["request"].user
+        from django.contrib.auth import get_user_model
+
+        User = get_user_model()
+        request_user = self.context["request"].user
+        data_source_user_id = validated_data.pop("data_source_user_id", None)
+
+        if request_user.is_staff and data_source_user_id:
+            try:
+                data_source_user = User.objects.get(pk=data_source_user_id)
+            except User.DoesNotExist as exc:
+                raise serializers.ValidationError(
+                    {"data_source_user_id": "Invalid data source user."}
+                ) from exc
+
+            financier = validated_data.get("financier")
+            if (
+                not financier
+                or data_source_user.client_id != getattr(financier, "pk", financier)
+            ):
+                raise serializers.ValidationError(
+                    {
+                        "data_source_user_id": (
+                            "Data source user must belong to the selected financier."
+                        )
+                    }
+                )
+            validated_data["created_by"] = data_source_user
+        else:
+            validated_data["created_by"] = request_user
+
         return super().create(validated_data)
 
     @transaction.atomic

--- a/apps/collateral/api/views.py
+++ b/apps/collateral/api/views.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import logging
 
-from django.db.models import Count, Q, QuerySet
+from django.db.models import Count, Q, QuerySet, Sum
 from django.utils import timezone
 from rest_framework import filters, status
 from rest_framework.decorators import action
@@ -118,6 +118,7 @@ class CollateralRegistrationViewSet(BaseViewSet):
                 "financier",
                 "individual_debtor",
                 "company_debtor",
+                "created_by",
             ).filter(created_by__client=self.request.user.client)
 
         return CollateralRegistration.objects.select_related(
@@ -126,6 +127,7 @@ class CollateralRegistrationViewSet(BaseViewSet):
             "company_debtor",
             "company_debtor__company",
             "currency",
+            "created_by",
         ).all()
 
     # ------------------------------------------------------------------
@@ -251,14 +253,17 @@ class CollateralRegistrationViewSet(BaseViewSet):
 
         """
         today = timezone.now().date()
-        aggregates: dict = CollateralRegistration.objects.aggregate(
-            active_agreements=Count(
-                "id",
-                filter=Q(
-                    agreement_start_date__lte=today,
-                    agreement_end_date__gte=today,
-                ),
-            ),
+        qs = CollateralRegistration.objects.all()
+        # Client users should only see their own portfolio totals.
+        if not request.user.is_staff and getattr(request.user, "client_id", None):
+            qs = qs.filter(financier_id=request.user.client_id)
+
+        active_filter = Q(
+            agreement_start_date__lte=today,
+            agreement_end_date__gte=today,
+        )
+        aggregates: dict = qs.aggregate(
+            active_agreements=Count("id", filter=active_filter),
             pending_discharge_confirmation=Count(
                 "id",
                 filter=Q(
@@ -266,7 +271,10 @@ class CollateralRegistrationViewSet(BaseViewSet):
                     is_discharged=False,
                 ),
             ),
+            total_active_loan_value=Sum("total_debt", filter=active_filter),
         )
+        if aggregates["total_active_loan_value"] is None:
+            aggregates["total_active_loan_value"] = 0
 
         serializer = CollateralDashboardSerializer(data=aggregates)
         serializer.is_valid(raise_exception=True)

--- a/apps/collateral/api/views.py
+++ b/apps/collateral/api/views.py
@@ -17,7 +17,10 @@ from rest_framework.response import Response
 from rest_framework.exceptions import ValidationError
 
 from django_filters.rest_framework import DjangoFilterBackend
-from apps.common.utils.helpers import extract_error_message
+from apps.common.utils.helpers import (
+    extract_error_message,
+    scope_registry_to_client_portfolio,
+)
 from apps.users.utils.permissions import HasRole, roles_allowed
 from apps.asset_management.api.views import StandardResultsSetPagination
 from apps.collateral.models.models import CollateralRegistration
@@ -69,7 +72,23 @@ class CollateralRegistrationViewSet(BaseViewSet):
         "currency",
         "debtor_type",
     ]
-    search_fields: list[str] = [
+    SEARCH_FIELD_MAP: dict[str, list[str]] = {
+        "agreement_number": ["agreement_number"],
+        "debtor": [
+            "individual_debtor__first_name",
+            "individual_debtor__last_name",
+            "individual_debtor__identification_number",
+            "company_debtor__branch_name",
+            "company_debtor__company__registration_name",
+            "company_debtor__company__trading_name",
+        ],
+        "reg_serial_number": [
+            "serial_number",
+            "asset_registration_number",
+            "chassis_number",
+        ],
+    }
+    DEFAULT_SEARCH_FIELDS: list[str] = [
         "agreement_number",
         "individual_debtor__first_name",
         "individual_debtor__last_name",
@@ -91,6 +110,17 @@ class CollateralRegistrationViewSet(BaseViewSet):
     ]
     ordering: list[str] = ["-lodge_date"]
 
+    @property
+    def search_fields(self) -> list[str]:
+        """
+        Scopes ``SearchFilter`` to the fields backing the selected
+        ``search_field`` criteria (e.g. "Agreement Number", "Debtor",
+        "Reg/Serial Number"). Any unrecognised/absent value searches the
+        full default field set.
+        """
+        search_field = self.request.query_params.get("search_field")
+        return self.SEARCH_FIELD_MAP.get(search_field, self.DEFAULT_SEARCH_FIELDS)
+
     def get_serializer_class(self):
         """
         Return the appropriate serializer class based on the requested action.
@@ -105,23 +135,13 @@ class CollateralRegistrationViewSet(BaseViewSet):
         Returns all collateral records with party relations eagerly loaded via
         ``select_related`` to prevent N+1 queries when list responses render
         ``financier_display`` and ``debtor_display``.
-        """
-        if self.request.user.roles.filter(
-            name__in=[
-                "client_user",
-                "client_admin",
-                "individual_client",
-                "company_client",
-            ]
-        ).exists():
-            return CollateralRegistration.objects.select_related(
-                "financier",
-                "individual_debtor",
-                "company_debtor",
-                "created_by",
-            ).filter(created_by__client=self.request.user.client)
 
-        return CollateralRegistration.objects.select_related(
+        Client users only see records belonging to their own portfolio, i.e.
+        records where their client is the ``financier``. This mirrors the
+        filter used by ``stats()`` so the list total and headline counts
+        never disagree.
+        """
+        qs = CollateralRegistration.objects.select_related(
             "financier",
             "individual_debtor",
             "company_debtor",
@@ -129,6 +149,16 @@ class CollateralRegistrationViewSet(BaseViewSet):
             "currency",
             "created_by",
         ).all()
+        qs = scope_registry_to_client_portfolio(qs, self.request.user)
+
+        # The main dashboard table should only surface active and
+        # pending-discharge agreements; already-discharged records are
+        # excluded from the list (but remain reachable directly by id for
+        # retrieve/update/delete/discharge).
+        if self.action == "list":
+            qs = qs.filter(is_discharged=False)
+
+        return qs
 
     # ------------------------------------------------------------------
     # Audit-logged CRUD hooks
@@ -148,7 +178,7 @@ class CollateralRegistrationViewSet(BaseViewSet):
             )
 
         except Exception as e:
-            logger.error(f"Error creating collateral registration: {e}")
+            logger.error("Error creating collateral registration: %s", e)
             return self._create_rendered_response(
                 {"error": "Something went wrong"},
                 status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -171,7 +201,7 @@ class CollateralRegistrationViewSet(BaseViewSet):
             )
 
         except Exception as e:
-            logger.error(f"Error updating collateral registration: {e}")
+            logger.error("Error updating collateral registration: %s", e)
             return self._create_rendered_response(
                 {"error": "Something went wrong"}, status.HTTP_500_INTERNAL_SERVER_ERROR
             )
@@ -181,12 +211,14 @@ class CollateralRegistrationViewSet(BaseViewSet):
             instance = self.get_object()
             self.perform_destroy(instance)
             logger.info(
-                f"Collateral registration with agreement number {instance.agreement_number} deleted by user {request.user}"
+                "Collateral registration with agreement number %s deleted by user %s",
+                instance.agreement_number,
+                request.user,
             )
             return Response(status=status.HTTP_204_NO_CONTENT)
 
         except Exception as e:
-            logger.error(f"Error deleting collateral registration: {e}")
+            logger.error("Error deleting collateral registration: %s", e)
             return self._create_rendered_response(
                 {"error": "Something went wrong"}, status.HTTP_500_INTERNAL_SERVER_ERROR
             )
@@ -253,14 +285,15 @@ class CollateralRegistrationViewSet(BaseViewSet):
 
         """
         today = timezone.now().date()
-        qs = CollateralRegistration.objects.all()
-        # Client users should only see their own portfolio totals.
-        if not request.user.is_staff and getattr(request.user, "client_id", None):
-            qs = qs.filter(financier_id=request.user.client_id)
+        qs = scope_registry_to_client_portfolio(
+            CollateralRegistration.objects.all(),
+            request.user,
+        )
 
         active_filter = Q(
             agreement_start_date__lte=today,
             agreement_end_date__gte=today,
+            is_discharged=False,
         )
         aggregates: dict = qs.aggregate(
             active_agreements=Count("id", filter=active_filter),

--- a/apps/common/api/views.py
+++ b/apps/common/api/views.py
@@ -220,7 +220,7 @@ class LocationViewSet(BaseViewSet):
 
     @CacheService.cached(tag_prefix="locations:provinces")
     def provinces(self, request):
-        queryset = Province.objects.select_related('country').filter(is_active=True)
+        queryset = Province.objects.select_related("country").filter(is_active=True)
         if country_id := request.query_params.get("country_id"):
             queryset = queryset.filter(country_id=country_id)
 
@@ -254,7 +254,7 @@ class LocationViewSet(BaseViewSet):
         tag_prefix="locations:cities", timeout=CacheService.LONG_CACHE_TIMEOUT
     )
     def cities(self, request):
-        queryset = City.objects.select_related('province').filter(is_active=True)
+        queryset = City.objects.select_related("province").filter(is_active=True)
         province_id = request.query_params.get("province_id")
         country_id = request.query_params.get("country_id")
 
@@ -290,7 +290,7 @@ class LocationViewSet(BaseViewSet):
         tag_prefix="locations:suburbs", timeout=CacheService.LONG_CACHE_TIMEOUT
     )
     def suburbs(self, request):
-        queryset = Suburb.objects.select_related('city').filter(is_active=True)
+        queryset = Suburb.objects.select_related("city").filter(is_active=True)
         city_id = request.query_params.get("city_id")
         province_id = request.query_params.get("province_id")
         country_id = request.query_params.get("country_id")
@@ -341,7 +341,10 @@ class LocationViewSet(BaseViewSet):
 
 
 class SuburbViewSet(viewsets.ReadOnlyModelViewSet):
-    queryset = Suburb.objects.filter(is_active=True)
+    # city -> province -> country for every row, so all three must be joined.
+    queryset = Suburb.objects.select_related("city__province__country").filter(
+        is_active=True
+    )
     serializer_class = SuburbViewSerializer
     permission_classes = [IsAuthenticated]
     pagination_class = None

--- a/apps/common/utils/helpers.py
+++ b/apps/common/utils/helpers.py
@@ -1,8 +1,38 @@
+from __future__ import annotations
+
+from django.db.models import QuerySet
 from rest_framework.exceptions import ValidationError
+
+CLIENT_ROLE_NAMES: tuple[str, ...] = (
+    "client_user",
+    "client_admin",
+    "individual_client",
+    "company_client",
+)
+
+
+def scope_registry_to_client_portfolio(
+    queryset: QuerySet, user, *, financier_field: str = "financier_id"
+):
+    """
+    Limit client-role users to records where their organisation is the
+    financier.  Staff/admin users without those roles see the full registry.
+
+    Both list and stats endpoints must call this helper so headline counts
+    never disagree with the table below.
+    """
+    if (
+        user.is_authenticated
+        and user.client_id
+        and user.roles.filter(name__in=CLIENT_ROLE_NAMES).exists()
+    ):
+        return queryset.filter(**{financier_field: user.client_id})
+    return queryset
+
 
 def extract_error_message(error):
     """
-    Recursively extract the first human-readable error message 
+    Recursively extract the first human-readable error message
     from the Validation Error.
     """
     if isinstance(error, ValidationError):

--- a/apps/hire_purchase/api/serializers.py
+++ b/apps/hire_purchase/api/serializers.py
@@ -31,6 +31,9 @@ class HirePurchaseRegistrationSerializer(serializers.ModelSerializer):
         source="financier", read_only=True
     )
     purchaser_display = serializers.SerializerMethodField(read_only=True)
+    data_source_display = serializers.SerializerMethodField(read_only=True)
+    data_source_position = serializers.SerializerMethodField(read_only=True)
+    data_source_user_id = serializers.IntegerField(write_only=True, required=False)
     currency = serializers.SlugRelatedField(
         slug_field="code",
         queryset=Currency.objects.all(),
@@ -72,6 +75,9 @@ class HirePurchaseRegistrationSerializer(serializers.ModelSerializer):
             "closure_confirmed_at",
             "is_active",
             "is_pending_closure",
+            "data_source_display",
+            "data_source_position",
+            "data_source_user_id",
             "date_created",
             "date_updated",
             "updated_by",
@@ -89,6 +95,8 @@ class HirePurchaseRegistrationSerializer(serializers.ModelSerializer):
             "is_pending_closure",
             "financier_display",
             "purchaser_display",
+            "data_source_display",
+            "data_source_position",
         ]
         extra_kwargs = {
             "mv_registration_number": {"required": False},
@@ -113,6 +121,16 @@ class HirePurchaseRegistrationSerializer(serializers.ModelSerializer):
         if obj.purchaser_company:
             return str(obj.purchaser_company)
         return ""
+
+    def get_data_source_display(self, obj: HirePurchaseRegistration) -> str:
+        if obj.created_by is None:
+            return ""
+        return obj.created_by.get_full_name() or obj.created_by.username or ""
+
+    def get_data_source_position(self, obj: HirePurchaseRegistration) -> str:
+        if obj.created_by is None:
+            return ""
+        return obj.created_by.position or ""
 
     # ------------------------------------------------------------------
     # Field-level validation
@@ -246,7 +264,36 @@ class HirePurchaseRegistrationSerializer(serializers.ModelSerializer):
 
     @transaction.atomic
     def create(self, validated_data: dict) -> HirePurchaseRegistration:
-        validated_data["created_by"] = self.context["request"].user
+        from django.contrib.auth import get_user_model
+
+        User = get_user_model()
+        request_user = self.context["request"].user
+        data_source_user_id = validated_data.pop("data_source_user_id", None)
+
+        if request_user.is_staff and data_source_user_id:
+            try:
+                data_source_user = User.objects.get(pk=data_source_user_id)
+            except User.DoesNotExist as exc:
+                raise serializers.ValidationError(
+                    {"data_source_user_id": "Invalid data source user."}
+                ) from exc
+
+            financier = validated_data.get("financier")
+            if (
+                not financier
+                or data_source_user.client_id != getattr(financier, "pk", financier)
+            ):
+                raise serializers.ValidationError(
+                    {
+                        "data_source_user_id": (
+                            "Data source user must belong to the selected financier."
+                        )
+                    }
+                )
+            validated_data["created_by"] = data_source_user
+        else:
+            validated_data["created_by"] = request_user
+
         return super().create(validated_data)
 
     @transaction.atomic

--- a/apps/hire_purchase/api/serializers.py
+++ b/apps/hire_purchase/api/serializers.py
@@ -13,7 +13,6 @@ from rest_framework import serializers
 from apps.hire_purchase.models import HirePurchaseRegistration
 from apps.common.models import Currency
 
-
 # ---------------------------------------------------------------------------
 # Hire Purchase serializers
 # ---------------------------------------------------------------------------
@@ -279,9 +278,8 @@ class HirePurchaseRegistrationSerializer(serializers.ModelSerializer):
                 ) from exc
 
             financier = validated_data.get("financier")
-            if (
-                not financier
-                or data_source_user.client_id != getattr(financier, "pk", financier)
+            if not financier or data_source_user.client_id != getattr(
+                financier, "pk", financier
             ):
                 raise serializers.ValidationError(
                     {
@@ -302,6 +300,62 @@ class HirePurchaseRegistrationSerializer(serializers.ModelSerializer):
     ) -> HirePurchaseRegistration:
         validated_data["updated_by"] = self.context["request"].user
         return super().update(instance, validated_data)
+
+
+class HirePurchaseRegistrationListSerializer(HirePurchaseRegistrationSerializer):
+    """
+    Lightweight read-only serializer optimized for list endpoints and
+    dashboards, mirroring the shape returned by the Collateral and Asset
+    Registry list endpoints.
+    """
+
+    lodge_date = serializers.DateField(read_only=True, format="%d-%b-%y")
+    agreement_start_date = serializers.DateField(read_only=True, format="%d-%b-%y")
+    agreement_end_date = serializers.DateField(read_only=True, format="%d-%b-%y")
+    currency_code = serializers.CharField(source="currency.code", read_only=True)
+    description = serializers.SerializerMethodField(
+        read_only=True,
+        help_text="Concatenated make and model for display purposes.",
+    )
+    primary_identifier = serializers.SerializerMethodField(
+        read_only=True,
+        help_text="Returns the MV registration number for vehicles, or the serial number otherwise.",
+    )
+
+    class Meta(HirePurchaseRegistrationSerializer.Meta):
+        """Inherits from HirePurchaseRegistrationSerializer.Meta, but overrides fields to a smaller subset for list performance."""
+
+        fields = [
+            "id",
+            "lodge_date",
+            "agreement_number",
+            "financier_display",
+            "purchaser_display",
+            "description",
+            "primary_identifier",
+            "currency_code",
+            "purchase_amount",
+            "agreement_start_date",
+            "agreement_end_date",
+            "closure_confirmed",
+        ]
+        read_only_fields = fields
+
+    def get_description(self, obj: HirePurchaseRegistration) -> str:
+        """Gets the description for the asset, which is a concatenation of the make and model."""
+        if obj.make and obj.model:
+            return f"{obj.make} {obj.model}"
+        if obj.make:
+            return obj.make
+        if obj.model:
+            return obj.model
+        return ""
+
+    def get_primary_identifier(self, obj: HirePurchaseRegistration) -> str:
+        """Gets the primary identifier for the asset, which is the MV registration number for vehicles or the serial number for other asset types."""
+        if obj.asset_type == "vehicles":
+            return obj.mv_registration_number
+        return obj.serial_number
 
 
 class HirePurchaseClosureSerializer(serializers.ModelSerializer):

--- a/apps/hire_purchase/api/views.py
+++ b/apps/hire_purchase/api/views.py
@@ -71,9 +71,7 @@ class HirePurchaseRegistrationViewSet(BaseViewSet):
         "serial_number",
         "mv_registration_number",
         "chassis_number",
-        "financier__username",
-        "financier__first_name",
-        "financier__last_name",
+        "financier__name",
         "make",
         "model",
     ]

--- a/apps/hire_purchase/api/views.py
+++ b/apps/hire_purchase/api/views.py
@@ -20,13 +20,17 @@ from django_filters.rest_framework import DjangoFilterBackend
 
 from apps.asset_management.api.views import StandardResultsSetPagination
 from apps.common.api.views import BaseViewSet
-from apps.common.utils.helpers import extract_error_message
+from apps.common.utils.helpers import (
+    extract_error_message,
+    scope_registry_to_client_portfolio,
+)
 from apps.hire_purchase.models.models import HirePurchaseRegistration
 from apps.users.services.audit_service import create_audit_log
 from apps.users.utils.permissions import HasRole, roles_allowed
 from .serializers import (
     HirePurchaseClosureSerializer,
     HirePurchaseDashboardSerializer,
+    HirePurchaseRegistrationListSerializer,
     HirePurchaseRegistrationSerializer,
 )
 
@@ -61,7 +65,22 @@ class HirePurchaseRegistrationViewSet(BaseViewSet):
         "closure_confirmed",
         "currency",
     ]
-    search_fields: list[str] = [
+    SEARCH_FIELD_MAP: dict[str, list[str]] = {
+        "agreement_number": ["agreement_number"],
+        "purchaser": [
+            "purchaser_individual__first_name",
+            "purchaser_individual__last_name",
+            "purchaser_company__branch_name",
+            "purchaser_company__company__trading_name",
+            "purchaser_company__company__registration_name",
+        ],
+        "reg_serial_number": [
+            "serial_number",
+            "mv_registration_number",
+            "chassis_number",
+        ],
+    }
+    DEFAULT_SEARCH_FIELDS: list[str] = [
         "agreement_number",
         "purchaser_individual__first_name",
         "purchaser_individual__last_name",
@@ -83,16 +102,54 @@ class HirePurchaseRegistrationViewSet(BaseViewSet):
     ]
     ordering: list[str] = ["-lodge_date"]
 
+    @property
+    def search_fields(self) -> list[str]:
+        """
+        Scopes ``SearchFilter`` to the fields backing the selected
+        ``search_field`` criteria (e.g. "Agreement Number", "Purchaser Name",
+        "Reg/Serial Number"). Any unrecognised/absent value searches the
+        full default field set.
+        """
+        search_field = self.request.query_params.get("search_field")
+        return self.SEARCH_FIELD_MAP.get(search_field, self.DEFAULT_SEARCH_FIELDS)
+
+    def get_serializer_class(self):
+        """
+        Return the appropriate serializer class based on the requested action.
+        We return the lighter ListSerializer for list actions for performance,
+        matching the Collateral and Asset Registry list endpoints.
+        """
+        if self.action == "list":
+            return HirePurchaseRegistrationListSerializer
+        return super().get_serializer_class()
+
     def get_queryset(self) -> QuerySet[HirePurchaseRegistration]:
         """
         Returns all HP records eagerly loaded via ``select_related``.
+
+        Client users only see records belonging to their own portfolio, i.e.
+        records where their client is the ``financier``. This mirrors the
+        filter used by ``stats()`` so the list total and headline counts
+        never disagree.
+
+        The main dashboard table should only surface active and
+        pending-closure agreements; already-closed records are excluded
+        from the list (but remain reachable directly by id for
+        retrieve/update/delete/confirm-closure).
         """
-        return HirePurchaseRegistration.objects.select_related(
+        qs = HirePurchaseRegistration.objects.select_related(
             "financier",
             "purchaser_individual",
             "purchaser_company",
             "purchaser_company__company",
         ).all()
+
+        qs = scope_registry_to_client_portfolio(qs, self.request.user)
+
+        if self.action == "list":
+            qs = qs.filter(closure_confirmed=False)
+
+        return qs
 
     # ------------------------------------------------------------------
     # Audit-logged CRUD hooks
@@ -196,14 +253,21 @@ class HirePurchaseRegistrationViewSet(BaseViewSet):
     def stats(self, request: Request) -> Response:
         """
         Returns the three headline statistics shown at the top of the HP
+        dashboard.
         """
         today = timezone.now().date()
+        qs = scope_registry_to_client_portfolio(
+            HirePurchaseRegistration.objects.all(),
+            request.user,
+        )
 
-        # Single aggregate call for the two count metrics.
-        aggregates: dict = HirePurchaseRegistration.objects.aggregate(
+        # Single aggregate call for the two count metrics. `active_agreements`
+        # excludes already-closed records so it can never disagree with the
+        # main table, which only ever shows open (non-closed) agreements.
+        aggregates: dict = qs.aggregate(
             active_agreements=Count(
                 "id",
-                filter=Q(agreement_end_date__gte=today),
+                filter=Q(agreement_end_date__gte=today, closure_confirmed=False),
             ),
             pending_closure_confirmation=Count(
                 "id",
@@ -216,9 +280,7 @@ class HirePurchaseRegistrationViewSet(BaseViewSet):
 
         # Distinct-financier count: cannot be folded into the aggregate above
         # without a subquery, so a second lightweight query is used.
-        number_of_financiers: int = (
-            HirePurchaseRegistration.objects.values("financier_id").distinct().count()
-        )
+        number_of_financiers: int = qs.values("financier_id").distinct().count()
 
         serializer = HirePurchaseDashboardSerializer(
             data={

--- a/apps/users/admin.py
+++ b/apps/users/admin.py
@@ -19,7 +19,7 @@ class CustomUserCreationForm(forms.ModelForm):
 
     class Meta:
         model = CustomUser
-        fields = ("email", "username")
+        fields = ("email", "username", "first_name", "last_name", "position")
 
     def clean_password2(self):
         password1 = self.cleaned_data.get("password1")
@@ -98,7 +98,7 @@ class CustomUserAdmin(UserAdmin):
         (None, {"fields": ("username", "password")}),
         (
             _("Personal info"),
-            {"fields": ("first_name", "last_name", "email", "profile_picture")},
+            {"fields": ("first_name", "last_name", "email", "position", "profile_picture")},
         ),
         (
             _("Permissions"),
@@ -144,6 +144,7 @@ class CustomUserAdmin(UserAdmin):
                     "password2",
                     "first_name",
                     "last_name",
+                    "position",
                     "is_staff",
                     "is_active",
                 ),

--- a/apps/users/api/serializers.py
+++ b/apps/users/api/serializers.py
@@ -43,6 +43,7 @@ class UserCreateSerializer(serializers.ModelSerializer):
             "password",
             "first_name",
             "last_name",
+            "position",
             "client_id",
             "role_id",
             "is_staff",

--- a/apps/users/api/serializers.py
+++ b/apps/users/api/serializers.py
@@ -95,18 +95,30 @@ class ClientUserSerializer(serializers.ModelSerializer):
 
 
 class UserMiniSerializer(serializers.ModelSerializer):
+    is_company_client = serializers.SerializerMethodField()
+    client_id = serializers.IntegerField(source="client.id", read_only=True, allow_null=True)
+    client_name = serializers.CharField(source="client.name", read_only=True, allow_null=True)
+
     class Meta:
         model = User
         fields = [
             "id",
             "username",
             "email",
+            "first_name",
+            "last_name",
+            "position",
             "user_type",
             "is_verified",
             "is_staff",
             "is_superuser",
-            "client",
+            "is_company_client",
+            "client_id",
+            "client_name",
         ]
+
+    def get_is_company_client(self, obj):
+        return bool(obj.client and obj.client.is_company_client)
 
 
 class CustomTokenObtainPairSerializer(TokenObtainPairSerializer):
@@ -156,6 +168,7 @@ class UserSerializer(serializers.ModelSerializer):
     client = MinimalClientSerializer(read_only=True)
     profile_object = serializers.SerializerMethodField()
     roles = RoleSerializer(many=True, read_only=True)
+    is_company_client = serializers.SerializerMethodField()
 
     class Meta:
         model = User
@@ -166,12 +179,14 @@ class UserSerializer(serializers.ModelSerializer):
             "user_type",
             "first_name",
             "last_name",
+            "position",
             "client",
             "profile_object",
             "roles",
             "is_verified",
             "is_staff",
             "is_superuser",
+            "is_company_client",
             "last_login",
             "date_joined",
         ]
@@ -184,7 +199,11 @@ class UserSerializer(serializers.ModelSerializer):
             "roles",
             "client",
             "profile_object",
+            "is_company_client",
         ]
+
+    def get_is_company_client(self, obj):
+        return bool(obj.client and obj.client.is_company_client)
 
     def get_profile_object(self, obj):
         if not obj.profile_object:

--- a/apps/users/services/user_service.py
+++ b/apps/users/services/user_service.py
@@ -87,6 +87,7 @@ class UserCreationService:
             password=user_data["password"],
             first_name=user_data.get("first_name", ""),
             last_name=user_data.get("last_name", ""),
+            position=user_data.get("position", "") or None,
             client=client,
             is_staff=user_data.get("is_staff", False),
             is_verified=user_data.get("is_verified", False),
@@ -148,6 +149,7 @@ class UserCreationService:
             is_verified=user_data.get("is_verified", True),
             first_name=user_data.get("first_name", ""),
             last_name=user_data.get("last_name", ""),
+            position=user_data.get("position", "") or None,
         )
 
         if role:

--- a/core/settings.py
+++ b/core/settings.py
@@ -284,11 +284,11 @@ SIMPLE_JWT = {
 }
 
 # CSRF Settings
-CSRF_TRUSTED_ORIGINS = os.getenv("CSRF_TRUSTED_ORIGINS", "").split(",")
+CSRF_TRUSTED_ORIGINS = getenv_list("CSRF_TRUSTED_ORIGINS")
 
 # CORS Settings
 # https://github.com/adamchainz/django-cors-headers
-CORS_ALLOWED_ORIGINS = os.getenv("CORS_ALLOWED_ORIGINS", "").split(",")
+CORS_ALLOWED_ORIGINS = getenv_list("CORS_ALLOWED_ORIGINS")
 CORS_ALLOW_CREDENTIALS = True  # Allow cookies to be sent
 CORS_ALLOW_HEADERS = [
     "content-type",

--- a/deploy.sh
+++ b/deploy.sh
@@ -4,12 +4,12 @@ set -e
 #echo "Starting deployment at $(date)"
 
 # Stash local changes
-#git stash
+git stash
 
 DEPLOY_BRANCH="${DEPLOY_BRANCH:-main}"
 COMPOSE_FILE="docker-compose.prod.yml"
 
-#git pull origin "$DEPLOY_BRANCH"
+git pull origin "$DEPLOY_BRANCH"
 
 # Bring down containers
 docker compose -f "$COMPOSE_FILE" down --remove-orphans

--- a/deploy.sh
+++ b/deploy.sh
@@ -6,13 +6,14 @@ echo "Starting deployment at $(date)"
 # Stash local changes
 git stash
 
-git pull origin main
+DEPLOY_BRANCH="${DEPLOY_BRANCH:-main}"
+COMPOSE_FILE="docker-compose.prod.yml"
 
-docker system prune -f --volumes
+git pull origin "$DEPLOY_BRANCH"
 
 # Bring down containers
-docker compose down
+docker compose -f "$COMPOSE_FILE" down --remove-orphans
 
-docker compose up -d --build
+docker compose -f "$COMPOSE_FILE" up -d --build
 
 echo "Deployment completed at $(date)"

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 set -e 
 
-echo "Starting deployment at $(date)"
+#echo "Starting deployment at $(date)"
 
 # Stash local changes
-git stash
+#git stash
 
 DEPLOY_BRANCH="${DEPLOY_BRANCH:-main}"
 COMPOSE_FILE="docker-compose.prod.yml"
 
-git pull origin "$DEPLOY_BRANCH"
+#git pull origin "$DEPLOY_BRANCH"
 
 # Bring down containers
 docker compose -f "$COMPOSE_FILE" down --remove-orphans

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "assetsafe",
-  "version": "1.2.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "assetsafe",
-      "version": "1.2.0",
+      "version": "1.0.0",
       "dependencies": {
         "@fontsource-variable/geist": "^5.2.8",
         "@hookform/resolvers": "^3.9.1",
@@ -30,7 +30,6 @@
         "lucide-react": "^1.16.0",
         "radix-ui": "^1.4.3",
         "react": "^19.2.5",
-        "react-day-picker": "^10.0.1",
         "react-dom": "^19.2.5",
         "react-hook-form": "^7.54.2",
         "react-router-dom": "^7.15.0",
@@ -92,6 +91,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -469,12 +469,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@date-fns/tz": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.5.0.tgz",
-      "integrity": "sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==",
-      "license": "MIT"
-    },
     "node_modules/@dotenvx/dotenvx": {
       "version": "1.66.0",
       "resolved": "https://registry.npmjs.org/@dotenvx/dotenvx/-/dotenvx-1.66.0.tgz",
@@ -642,27 +636,6 @@
       },
       "peerDependencies": {
         "@noble/ciphers": "^1.0.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1284,6 +1257,7 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -4089,6 +4063,7 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.9.tgz",
       "integrity": "sha512-Oa44XkaI3kCNN6ME0KByU3xT3SEUNOMfZpHxL6+wFoTm+OeUFYHKdeYVe0aOXlRDm/f15sgLwEt2HDorIdW8+A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.100.9"
       },
@@ -4242,6 +4217,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
       "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -4252,6 +4228,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4262,6 +4239,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4332,6 +4310,7 @@
       "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.1",
         "@typescript-eslint/types": "8.59.1",
@@ -4600,6 +4579,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4956,6 +4936,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -5967,6 +5948,7 @@
       "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -6023,6 +6005,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -7263,6 +7246,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
       "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -8904,6 +8888,7 @@
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9261,34 +9246,9 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-day-picker": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-10.0.1.tgz",
-      "integrity": "sha512-eNh6BlwcYInWaJtRv18mXQ06Ys/H6rdTZAnTaSdOYJuTpwP1JMCHNd1FDRadA+gbeinq+psdULN5Xnowy9mV8w==",
-      "license": "MIT",
-      "dependencies": {
-        "@date-fns/tz": "^1.4.1",
-        "date-fns": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://github.com/sponsors/gpbl"
-      },
-      "peerDependencies": {
-        "@types/react": ">=16.8.0",
-        "react": ">=16.8.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
       }
     },
     "node_modules/react-dom": {
@@ -9296,6 +9256,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -9308,6 +9269,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.54.2.tgz",
       "integrity": "sha512-eHpAUgUjWbZocoQYUHposymRb4ZP6d0uwUnooL2uOybA9/3tPUvoAKqEWK1WaSiTxxOfTpffNZP7QwlnM3/gEg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -9717,6 +9679,7 @@
       "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.4.tgz",
       "integrity": "sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -10385,6 +10348,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10644,6 +10608,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -10977,6 +10942,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -91,7 +91,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -638,10 +637,31 @@
         "@noble/ciphers": "^1.0.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1257,7 +1277,6 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -3687,6 +3706,37 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
       "version": "1.0.0-rc.17",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
@@ -4063,7 +4113,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.9.tgz",
       "integrity": "sha512-Oa44XkaI3kCNN6ME0KByU3xT3SEUNOMfZpHxL6+wFoTm+OeUFYHKdeYVe0aOXlRDm/f15sgLwEt2HDorIdW8+A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.100.9"
       },
@@ -4217,7 +4266,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
       "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -4228,7 +4276,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4239,7 +4286,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4310,7 +4356,6 @@
       "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.1",
         "@typescript-eslint/types": "8.59.1",
@@ -4579,7 +4624,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4936,7 +4980,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -5948,7 +5991,6 @@
       "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -6005,7 +6047,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -7246,7 +7287,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
       "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -8888,7 +8928,6 @@
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9246,7 +9285,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9256,7 +9294,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -9269,7 +9306,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.54.2.tgz",
       "integrity": "sha512-eHpAUgUjWbZocoQYUHposymRb4ZP6d0uwUnooL2uOybA9/3tPUvoAKqEWK1WaSiTxxOfTpffNZP7QwlnM3/gEg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -9679,7 +9715,6 @@
       "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.4.tgz",
       "integrity": "sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -10348,7 +10383,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10608,7 +10642,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -10942,7 +10975,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,7 +32,6 @@
     "lucide-react": "^1.16.0",
     "radix-ui": "^1.4.3",
     "react": "^19.2.5",
-    "react-day-picker": "^10.0.1",
     "react-dom": "^19.2.5",
     "react-hook-form": "^7.54.2",
     "react-router-dom": "^7.15.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -55,9 +55,25 @@ const queryClient = new QueryClient({
 });
 
 // Simple React Query persistence using localStorage via dehydrate/hydrate
+//
+// NOTE: Bump the "v" suffix whenever a backend/API response shape or
+// filtering change means previously-cached data could be stale/incorrect.
+// Since `refetchOnMount` is disabled below, a hydrated cache entry is
+// served indefinitely (across reloads) until explicitly invalidated, so
+// changing this key is the way to force every browser to drop its old
+// persisted cache and fetch fresh data.
+const RQ_CACHE_KEY = 'RQ:cache:v3';
+
 if (typeof window !== 'undefined') {
   try {
-    const cached = window.localStorage.getItem('RQ:cache:v1');
+    // Clear out any older cache versions so stale entries don't linger.
+    for (const key of Object.keys(window.localStorage)) {
+      if (key.startsWith('RQ:cache:') && key !== RQ_CACHE_KEY) {
+        window.localStorage.removeItem(key);
+      }
+    }
+
+    const cached = window.localStorage.getItem(RQ_CACHE_KEY);
     if (cached) {
       const parsed = JSON.parse(cached);
       hydrate(queryClient, parsed);
@@ -66,7 +82,7 @@ if (typeof window !== 'undefined') {
     const persist = () => {
       try {
         const data = dehydrate(queryClient);
-        window.localStorage.setItem('RQ:cache:v1', JSON.stringify(data));
+        window.localStorage.setItem(RQ_CACHE_KEY, JSON.stringify(data));
       } catch {
         // ignore
       }

--- a/frontend/src/api/authApi.ts
+++ b/frontend/src/api/authApi.ts
@@ -14,6 +14,10 @@ export interface AuthUser {
   first_name?: string;
   last_name?: string;
   role?: string;
+  position?: string;
+  is_company_client?: boolean;
+  client_id?: number;
+  client_name?: string;
   is_staff?: boolean;
   is_superuser?: boolean;
 }
@@ -51,6 +55,31 @@ export function normalizeAuthUser(raw: Record<string, unknown>): AuthUser {
         : typeof raw.role === 'string'
           ? raw.role
           : undefined,
+    position: typeof raw.position === 'string' ? raw.position : undefined,
+    is_company_client: raw.is_company_client === true,
+    client_id: (() => {
+      if (typeof raw.client_id === 'number') return raw.client_id;
+      if (typeof raw.client === 'number') return raw.client;
+      if (
+        raw.client &&
+        typeof raw.client === 'object' &&
+        typeof (raw.client as { id?: unknown }).id === 'number'
+      ) {
+        return Number((raw.client as { id: number }).id);
+      }
+      return undefined;
+    })(),
+    client_name: (() => {
+      if (typeof raw.client_name === 'string') return raw.client_name;
+      if (
+        raw.client &&
+        typeof raw.client === 'object' &&
+        typeof (raw.client as { name?: unknown }).name === 'string'
+      ) {
+        return (raw.client as { name: string }).name;
+      }
+      return undefined;
+    })(),
     is_staff: raw.is_staff === true,
     is_superuser: raw.is_superuser === true,
   };

--- a/frontend/src/api/clientsApi.ts
+++ b/frontend/src/api/clientsApi.ts
@@ -5,14 +5,46 @@ import {
   type SearchOption,
 } from '@/lib/searchResults';
 
+export interface CreateClientPayload {
+  individual_id?: number;
+  company_branch_id?: number;
+  client_type?: string;
+  status?: string;
+}
+
+export interface CreatedClient {
+  id: number;
+  name: string;
+}
+
 export const clientsApi = {
-  /** GET /api/clients/search/?q=... */
-  searchClients: async (query: string): Promise<SearchOption[]> => {
+  /** POST /api/clients/ */
+  createClient: async (payload: CreateClientPayload): Promise<CreatedClient> => {
+    const { data } = await axiosInstance.post<unknown>('/clients/', payload);
+    const raw =
+      data && typeof data === 'object' && 'data' in (data as object)
+        ? (data as { data: Record<string, unknown> }).data
+        : (data as Record<string, unknown>);
+
+    return {
+      id: Number(raw.id),
+      name: String(raw.name ?? `Client #${raw.id}`),
+    };
+  },
+
+  /** GET /api/clients/search/?q=...&entity_type=individual|company */
+  searchClients: async (
+    query: string,
+    options?: { entityType?: 'individual' | 'company' },
+  ): Promise<SearchOption[]> => {
     const term = query.trim();
     if (!term) return [];
 
     const { data } = await axiosInstance.get<unknown>('/clients/search/', {
-      params: { q: term },
+      params: {
+        q: term,
+        ...(options?.entityType ? { entity_type: options.entityType } : {}),
+      },
     });
 
     return unwrapSearchList(data).map((row) =>

--- a/frontend/src/api/clientsApi.ts
+++ b/frontend/src/api/clientsApi.ts
@@ -1,4 +1,5 @@
 import axiosInstance from './axiosInstance';
+import { unwrapApiData } from '@/lib/parsePaginatedApi';
 import {
   mapClientSearchResult,
   unwrapSearchList,
@@ -15,6 +16,22 @@ export interface CreateClientPayload {
 export interface CreatedClient {
   id: number;
   name: string;
+}
+
+export interface ClientUserOption {
+  id: number;
+  name: string;
+  position?: string;
+}
+
+export interface ClientDetail {
+  id: number;
+  name: string;
+  client_details?: {
+    full_name?: string;
+    first_name?: string;
+    last_name?: string;
+  };
 }
 
 export const clientsApi = {
@@ -50,5 +67,38 @@ export const clientsApi = {
     return unwrapSearchList(data).map((row) =>
       mapClientSearchResult(row as Record<string, unknown>),
     );
+  },
+
+  /** GET /api/clients/{id}/ */
+  getClient: async (id: number): Promise<ClientDetail> => {
+    const { data } = await axiosInstance.get<unknown>(`/clients/${id}/`);
+    const raw = unwrapApiData<Record<string, unknown>>(data);
+    return {
+      id: Number(raw.id),
+      name: String(raw.name ?? ''),
+      client_details: raw.client_details as ClientDetail['client_details'],
+    };
+  },
+
+  /** GET /api/clients/users/?client_id=... */
+  listClientUsers: async (clientId: number): Promise<ClientUserOption[]> => {
+    const { data } = await axiosInstance.get<unknown>('/clients/users/', {
+      params: { client_id: clientId },
+    });
+    const rows = unwrapSearchList(data);
+    return rows.map((row) => {
+      const item = row as Record<string, unknown>;
+      const first = String(item.first_name ?? '');
+      const last = String(item.last_name ?? '');
+      const name =
+        `${first} ${last}`.trim() ||
+        String(item.username ?? item.email ?? `User #${item.id}`);
+      return {
+        id: Number(item.id),
+        name,
+        position:
+          typeof item.position === 'string' ? item.position : undefined,
+      };
+    });
   },
 };

--- a/frontend/src/api/collateralApi.ts
+++ b/frontend/src/api/collateralApi.ts
@@ -71,7 +71,6 @@ function mapCollateralRecord(
 export const collateralApi = {
   getDashboard: async (params?: {
     search_field?: string;
-    search_value?: string;
   }): Promise<CollateralDashboard> => {
     const { data } = await axiosInstance.get('/collateral/stats/', { params });
     return unwrapApiData<CollateralDashboard>(data);
@@ -80,7 +79,6 @@ export const collateralApi = {
   getRecords: async (params?: {
     search?: string;
     search_field?: string;
-    search_value?: string;
     page?: number;
     page_size?: number;
   }): Promise<{ records: CollateralRecord[]; count: number }> => {

--- a/frontend/src/api/collateralApi.ts
+++ b/frontend/src/api/collateralApi.ts
@@ -58,6 +58,8 @@ function mapCollateralRecord(
       'company',
     financier_id: Number(record.financier ?? record.financier_id ?? 0),
     data_date: String(record.data_date ?? record.lodge_date ?? ''),
+    data_source_display: String(record.data_source_display ?? ''),
+    data_source_position: String(record.data_source_position ?? ''),
     status: record.is_discharged
       ? 'discharged'
       : record.is_pending_discharge

--- a/frontend/src/api/hirePurchaseApi.ts
+++ b/frontend/src/api/hirePurchaseApi.ts
@@ -1,6 +1,6 @@
 import axiosInstance from './axiosInstance';
 import { mapHirePurchaseFormToApi } from '@/lib/registryPayloads';
-import { unwrapApiData } from '@/lib/parsePaginatedApi';
+import { parsePaginatedList, unwrapApiData } from '@/lib/parsePaginatedApi';
 import type {
   ApiResponse,
   HirePurchaseDashboard,
@@ -28,6 +28,9 @@ function mapHirePurchaseRecord(
         record.purchaser_company ??
         0,
     ),
+    asset_description: String(
+      record.description ?? `${record.make ?? ''} ${record.model ?? ''}`.trim(),
+    ),
     asset_make: String(record.make ?? record.asset_make ?? ''),
     asset_model: String(record.model ?? record.asset_model ?? ''),
     asset_type: String(record.asset_type ?? ''),
@@ -37,6 +40,7 @@ function mapHirePurchaseRecord(
     reg_serial_number: String(
       record.mv_registration_number ??
         record.serial_number ??
+        record.primary_identifier ??
         record.reg_serial_number ??
         '',
     ),
@@ -71,15 +75,16 @@ export const hirePurchaseApi = {
   getDashboard: async (params?: {
     financier_id?: number;
   }): Promise<HirePurchaseDashboard> => {
-    const { data } = await axiosInstance.get<
-      ApiResponse<HirePurchaseDashboard>
-    >('/hire-purchase/stats/', { params });
-    return data.data ?? (data as unknown as HirePurchaseDashboard);
+    const { data } = await axiosInstance.get('/hire-purchase/stats/', {
+      params,
+    });
+    return unwrapApiData<HirePurchaseDashboard>(data);
   },
 
   getRecords: async (params?: {
     financier_id?: number;
     search?: string;
+    search_field?: string;
     page?: number;
     page_size?: number;
   }): Promise<{ records: HirePurchaseRecord[]; count: number }> => {
@@ -88,24 +93,10 @@ export const hirePurchaseApi = {
       ...rest,
       ...(financier_id ? { financier: financier_id } : {}),
     };
-    const { data } = await axiosInstance.get<any>('/hire-purchase/', {
+    const { data } = await axiosInstance.get('/hire-purchase/', {
       params: queryParams,
     });
-    const payload = data?.data ?? data;
-    const recordsRaw = payload?.results ?? payload?.data ?? payload ?? [];
-    const count =
-      typeof payload?.count === 'number'
-        ? payload.count
-        : Array.isArray(recordsRaw)
-          ? recordsRaw.length
-          : 0;
-    const records = Array.isArray(recordsRaw)
-      ? recordsRaw.map((record: Record<string, unknown>) =>
-          mapHirePurchaseRecord(record),
-        )
-      : [];
-
-    return { records, count };
+    return parsePaginatedList(data, mapHirePurchaseRecord);
   },
 
   getRecord: async (id: number): Promise<HirePurchaseRecord> => {

--- a/frontend/src/api/hirePurchaseApi.ts
+++ b/frontend/src/api/hirePurchaseApi.ts
@@ -1,5 +1,6 @@
 import axiosInstance from './axiosInstance';
 import { mapHirePurchaseFormToApi } from '@/lib/registryPayloads';
+import { unwrapApiData } from '@/lib/parsePaginatedApi';
 import type {
   ApiResponse,
   HirePurchaseDashboard,
@@ -7,6 +8,64 @@ import type {
   HirePurchaseFormData,
   User,
 } from '@/types';
+
+function mapHirePurchaseRecord(
+  record: Record<string, unknown>,
+): HirePurchaseRecord {
+  return {
+    id: Number(record.id),
+    lodge_date: String(record.lodge_date ?? ''),
+    agreement_number: String(record.agreement_number ?? ''),
+    purchaser_name: String(
+      record.purchaser_display ?? record.purchaser_name ?? '',
+    ),
+    purchaser_type:
+      (record.purchaser_type as HirePurchaseRecord['purchaser_type']) ??
+      'individual',
+    purchaser_id: Number(
+      record.purchaser_id ??
+        record.purchaser_individual ??
+        record.purchaser_company ??
+        0,
+    ),
+    asset_make: String(record.make ?? record.asset_make ?? ''),
+    asset_model: String(record.model ?? record.asset_model ?? ''),
+    asset_type: String(record.asset_type ?? ''),
+    asset_year: Number(record.year_of_make ?? record.asset_year ?? 0),
+    asset_condition:
+      (record.condition as HirePurchaseRecord['asset_condition']) ?? 'new',
+    reg_serial_number: String(
+      record.mv_registration_number ??
+        record.serial_number ??
+        record.reg_serial_number ??
+        '',
+    ),
+    chassis_number: String(record.chassis_number ?? ''),
+    engine_number: String(record.engine_number ?? ''),
+    currency: String(record.currency_code ?? record.currency ?? ''),
+    purchase_amount: Number(record.purchase_amount ?? 0),
+    instalment_amount: Number(record.instalment_amount ?? 0),
+    instalment_date: Number(
+      record.instalment_day ?? record.instalment_date ?? 1,
+    ),
+    total_paid_to_date: Number(record.total_paid_to_date ?? 0),
+    balance: Number(record.balance ?? 0),
+    start_date: String(record.agreement_start_date ?? record.start_date ?? ''),
+    end_date: String(record.agreement_end_date ?? record.end_date ?? ''),
+    financier_name: String(
+      record.financier_display ?? record.financier_name ?? '',
+    ),
+    financier_id: Number(record.financier ?? record.financier_id ?? 0),
+    data_date: String(record.data_date ?? record.lodge_date ?? ''),
+    data_source_display: String(record.data_source_display ?? ''),
+    data_source_position: String(record.data_source_position ?? ''),
+    status: (record.closure_confirmed
+      ? 'closed'
+      : record.is_pending_closure
+        ? 'pending_closure'
+        : 'active') as HirePurchaseRecord['status'],
+  };
+}
 
 export const hirePurchaseApi = {
   getDashboard: async (params?: {
@@ -41,58 +100,18 @@ export const hirePurchaseApi = {
           ? recordsRaw.length
           : 0;
     const records = Array.isArray(recordsRaw)
-      ? recordsRaw.map((record: any) => ({
-          id: record.id,
-          lodge_date: record.lodge_date,
-          agreement_number: record.agreement_number,
-          purchaser_name:
-            record.purchaser_display ?? record.purchaser_name ?? '',
-          purchaser_type: record.purchaser_type ?? 'individual',
-          purchaser_id:
-            record.purchaser_id ??
-            record.purchaser_individual ??
-            record.purchaser_company ??
-            0,
-          asset_make: record.make ?? record.asset_make ?? '',
-          asset_model: record.model ?? record.asset_model ?? '',
-          asset_type: record.asset_type,
-          asset_year: record.year_of_make ?? record.asset_year ?? 0,
-          asset_condition: record.condition ?? record.asset_condition ?? 'new',
-          reg_serial_number:
-            record.mv_registration_number ??
-            record.serial_number ??
-            record.reg_serial_number ??
-            '',
-          chassis_number: record.chassis_number ?? '',
-          engine_number: record.engine_number ?? '',
-          currency: record.currency_code ?? record.currency ?? '',
-          purchase_amount: record.purchase_amount ?? 0,
-          instalment_amount: record.instalment_amount ?? 0,
-          instalment_date: record.instalment_day ?? record.instalment_date ?? 1,
-          total_paid_to_date: record.total_paid_to_date ?? 0,
-          balance: record.balance ?? 0,
-          start_date: record.agreement_start_date ?? record.start_date ?? '',
-          end_date: record.agreement_end_date ?? record.end_date ?? '',
-          financier_name:
-            record.financier_display ?? record.financier_name ?? '',
-          financier_id: record.financier ?? record.financier_id ?? 0,
-          data_date: record.data_date ?? record.lodge_date ?? '',
-          status: (record.closure_confirmed
-            ? 'closed'
-            : record.is_pending_closure
-              ? 'pending_closure'
-              : 'active') as HirePurchaseRecord['status'],
-        }))
+      ? recordsRaw.map((record: Record<string, unknown>) =>
+          mapHirePurchaseRecord(record),
+        )
       : [];
 
     return { records, count };
   },
 
   getRecord: async (id: number): Promise<HirePurchaseRecord> => {
-    const { data } = await axiosInstance.get<ApiResponse<HirePurchaseRecord>>(
-      `/hire-purchase/${id}/`,
-    );
-    return data.data ?? (data as unknown as HirePurchaseRecord);
+    const { data } = await axiosInstance.get<unknown>(`/hire-purchase/${id}/`);
+    const raw = unwrapApiData<Record<string, unknown>>(data);
+    return mapHirePurchaseRecord(raw);
   },
 
   createRecord: async (

--- a/frontend/src/api/locationsApi.ts
+++ b/frontend/src/api/locationsApi.ts
@@ -1,56 +1,101 @@
 import axiosInstance from './axiosInstance';
-import type { ApiResponse } from '@/types';
-
-export interface SuburbOption {
-  id: number;
-  name: string;
-}
-
-export interface CityOption {
-  id: number;
-  name: string;
-}
 
 export interface CountryOption {
   id: number;
   name: string;
-  code?: string;
+}
+export interface ProvinceOption {
+  id: number;
+  name: string;
+  country_name: string;
+}
+export interface CityOption {
+  id: number;
+  name: string;
+  province_name: string;
+}
+export interface SuburbOption {
+  id: number;
+  name: string;
+  city_id?: number; // present when fetched via filtered /locations/suburbs/?city_id=X
+  city_name?: string; // present when fetched via /suburbs/ (SuburbViewSet)
+  country_name?: string; // present when fetched via /suburbs/ (SuburbViewSet)
 }
 
-function unwrapList<T>(data: unknown): T[] {
-  const payload = (data as { data?: unknown })?.data ?? data;
-  if (Array.isArray(payload)) return payload as T[];
-  const inner = (payload as { results?: unknown })?.results;
-  if (Array.isArray(inner)) return inner as T[];
+// ─── Internal helpers ─────────────────────────────────────────────────────────
+
+function rows(data: unknown): Record<string, unknown>[] {
+  const p = (data as { data?: unknown })?.data ?? data;
+  if (Array.isArray(p)) return p as Record<string, unknown>[];
+  const r = (p as { results?: unknown })?.results;
+  if (Array.isArray(r)) return r as Record<string, unknown>[];
   return [];
 }
+
+// ─── API ──────────────────────────────────────────────────────────────────────
 
 export const locationsApi = {
   getCountries: async (): Promise<CountryOption[]> => {
     const { data } = await axiosInstance.get('/common/locations/countries/');
-    return unwrapList<CountryOption>(data);
+    return rows(data).map((r) => ({
+      id: Number(r.id),
+      name: String(r.name ?? ''),
+    }));
   },
 
-  getCities: async (countryId: number): Promise<CityOption[]> => {
+  getProvinces: async (): Promise<ProvinceOption[]> => {
+    const { data } = await axiosInstance.get('/common/locations/provinces/');
+    // ProvinceSerializer returns: { id, name, country (string), … }
+    return rows(data).map((r) => ({
+      id: Number(r.id),
+      name: String(r.name ?? ''),
+      country_name: String(r.country ?? ''),
+    }));
+  },
+
+  getCities: async (countryId?: number): Promise<CityOption[]> => {
+    const params = countryId ? { country_id: countryId } : undefined;
     const { data } = await axiosInstance.get('/common/locations/cities/', {
-      params: { country_id: countryId },
+      params,
     });
-    return unwrapList<CityOption>(data);
+    // CitySerializer returns: { id, name, province (string name), … }
+    return rows(data).map((r) => ({
+      id: Number(r.id),
+      name: String(r.name ?? ''),
+      province_name: String(r.province ?? ''),
+    }));
   },
 
-  getSuburbs: async (cityId: number): Promise<SuburbOption[]> => {
+  /**
+   * Filtered suburbs — uses LocationViewSet which supports ?city_id=.
+   * Returns { id, name, city (string name) } — no parent IDs in GET response.
+   * We inject city_id ourselves when the caller provides it.
+   */
+  getSuburbs: async (cityId?: number): Promise<SuburbOption[]> => {
+    const params = cityId ? { city_id: cityId } : undefined;
     const { data } = await axiosInstance.get('/common/locations/suburbs/', {
-      params: { city_id: cityId },
+      params,
     });
-    return unwrapList<SuburbOption>(data);
+    return rows(data).map((r) => ({
+      id: Number(r.id),
+      name: String(r.name ?? ''),
+      city_id: cityId, // inject so auto-populate can find the parent city
+    }));
   },
 
-  searchSuburbs: async (query?: string): Promise<SuburbOption[]> => {
-    const { data } = await axiosInstance.get<ApiResponse<SuburbOption[]>>(
-      '/common/locations/suburbs/',
-      { params: query ? { search: query } : undefined },
-    );
-    const payload = data?.data ?? data;
-    return Array.isArray(payload) ? payload : [];
+  /**
+   * All suburbs with full hierarchy — uses SuburbViewSet (/common/suburbs/).
+   * Returns { id, name, city (city name), province (province name), country (country name) }.
+   * This is the only endpoint that exposes parent names without IDs.
+   * Used for the unfiltered pool so suburb-first selection can auto-populate city & country.
+   */
+  getAllSuburbsWithHierarchy: async (): Promise<SuburbOption[]> => {
+    const { data } = await axiosInstance.get('/common/suburbs/');
+    return rows(data).map((r) => ({
+      id: Number(r.id),
+      name: String(r.name ?? ''),
+      city_name: r.city ? String(r.city) : undefined,
+      country_name: r.country ? String(r.country) : undefined,
+    }));
   },
 };

--- a/frontend/src/api/usersApi.ts
+++ b/frontend/src/api/usersApi.ts
@@ -20,6 +20,8 @@ export interface CreateUserPayload {
   password: string;
   first_name?: string;
   last_name?: string;
+  position?: string;
+  client_id?: number;
   is_staff?: boolean;
   is_superuser?: boolean;
 }

--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -83,7 +83,7 @@ export function AppSidebar() {
               <SidebarNavLink
                 to="/collateral"
                 icon={Landmark}
-                label="Collateral"
+                label="Collateral Registry"
               />
               <SidebarNavLink
                 to="/hire-purchase"

--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -73,13 +73,6 @@ export function AppSidebar() {
           <SidebarGroupLabel>Dashboard</SidebarGroupLabel>
           <SidebarGroupContent>
             <SidebarMenu>
-              {isStaff ? (
-                <SidebarNavLink
-                  to="/registry"
-                  icon={Package}
-                  label="Asset Registry"
-                />
-              ) : null}
               <SidebarNavLink
                 to="/collateral"
                 icon={Landmark}
@@ -90,6 +83,13 @@ export function AppSidebar() {
                 icon={HandCoins}
                 label="Hire Purchase Registry"
               />
+              {isStaff ? (
+                <SidebarNavLink
+                  to="/registry"
+                  icon={Package}
+                  label="Asset Registry"
+                />
+              ) : null}
             </SidebarMenu>
           </SidebarGroupContent>
         </SidebarGroup>

--- a/frontend/src/components/app-sidebar.tsx
+++ b/frontend/src/components/app-sidebar.tsx
@@ -88,7 +88,7 @@ export function AppSidebar() {
               <SidebarNavLink
                 to="/hire-purchase"
                 icon={HandCoins}
-                label="Hire Purchase"
+                label="Hire Purchase Registry"
               />
             </SidebarMenu>
           </SidebarGroupContent>

--- a/frontend/src/components/clients/ClientCreateForm.tsx
+++ b/frontend/src/components/clients/ClientCreateForm.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useState } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { clientsApi } from '@/api/clientsApi';
+import { individualsApi } from '@/api/individualsApi';
+import { companiesApi } from '@/api/companiesApi';
+import AutocompleteInput from '@/components/shared/AutocompleteInput';
+import { Button } from '@/components/ui/button';
+
+interface ClientCreateFormProps {
+  onSuccess: (result: { id: number; name: string }) => void;
+  onCancel: () => void;
+  initialEntityType?: 'individual' | 'company';
+}
+
+export function ClientCreateForm({
+  onSuccess,
+  onCancel,
+  initialEntityType = 'company',
+}: ClientCreateFormProps) {
+  const [entityType, setEntityType] = useState<'individual' | 'company'>(
+    initialEntityType,
+  );
+  const [entityId, setEntityId] = useState<number>(0);
+  const [entityError, setEntityError] = useState('');
+
+  useEffect(() => {
+    setEntityType(initialEntityType);
+    setEntityId(0);
+    setEntityError('');
+  }, [initialEntityType]);
+
+  const { mutate: submit, isPending } = useMutation({
+    mutationFn: () =>
+      clientsApi.createClient(
+        entityType === 'individual'
+          ? { individual_id: entityId }
+          : { company_branch_id: entityId },
+      ),
+    onSuccess: (client) => {
+      toast.success(`Client "${client.name}" created`);
+      onSuccess(client);
+    },
+    onError: (err: unknown) => {
+      const data = (
+        err as { response?: { data?: Record<string, string | string[]> } }
+      )?.response?.data;
+      if (data && typeof data === 'object') {
+        const messages = Object.values(data).flat().join(' ');
+        if (messages) {
+          toast.error(messages);
+          return;
+        }
+      }
+      toast.error('Failed to create client');
+    },
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!entityId) {
+      setEntityError('Select an individual or company branch');
+      return;
+    }
+    setEntityError('');
+    submit();
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4 p-4" noValidate>
+      <div>
+        <label className="text-xs font-medium text-slate-600">Client Type</label>
+        <select
+          value={entityType}
+          onChange={(e) => {
+            setEntityType(e.target.value as 'individual' | 'company');
+            setEntityId(0);
+            setEntityError('');
+          }}
+          className="mt-1 h-8 w-full rounded border border-slate-300 bg-white px-2 text-sm focus:outline-none focus:border-[#0f7d8e]"
+        >
+          <option value="company">Company</option>
+          <option value="individual">Individual</option>
+        </select>
+      </div>
+
+      <AutocompleteInput
+        label={entityType === 'individual' ? 'Individual' : 'Company Branch'}
+        placeholder={
+          entityType === 'individual'
+            ? 'Search by name or national ID...'
+            : 'Search by name or registration number...'
+        }
+        queryKey={`client-create-${entityType}`}
+        fetchFn={(q) =>
+          entityType === 'company'
+            ? companiesApi.searchBranches(q)
+            : individualsApi.searchIndividuals(q)
+        }
+        error={entityError}
+        value={entityId || undefined}
+        onChange={(v) => {
+          setEntityId(Number(v));
+          setEntityError('');
+        }}
+      />
+
+      <p className="text-xs text-slate-500">
+        Creates a client record linked to the selected{' '}
+        {entityType === 'individual' ? 'individual' : 'company branch'}.
+      </p>
+
+      <div className="flex justify-end gap-2 border-t border-slate-200 pt-3">
+        <Button type="button" variant="ghost" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button type="submit" loading={isPending}>
+          Create Client
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/components/collateral/CollateralForm.tsx
+++ b/frontend/src/components/collateral/CollateralForm.tsx
@@ -1,7 +1,10 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useForm, useFormState, Controller } from 'react-hook-form';
 import { zodResolver } from '@/lib/zodResolver';
-import { applyApiValidationErrors, firstFormErrorMessage } from '@/lib/formErrors';
+import {
+  applyApiValidationErrors,
+  firstFormErrorMessage,
+} from '@/lib/formErrors';
 import type { FieldErrors } from 'react-hook-form';
 import { z } from 'zod';
 import { useMutation, useQuery } from '@tanstack/react-query';
@@ -15,6 +18,7 @@ import { Input } from '@/components/ui/input';
 import { DateInput } from '@/components/ui/DateInput';
 import AutocompleteInput from '@/components/shared/AutocompleteInput';
 import { Button } from '@/components/ui/button';
+import { ConfirmDialog } from '@/components/shared/ConfirmDialog';
 import { FormSectionHeader } from '@/components/shared/FormSectionHeader';
 import { FieldError } from '@/components/shared/FieldError';
 import { Modal } from '@/components/shared/Modal';
@@ -67,6 +71,17 @@ type CoreFormValues = z.infer<typeof collateralCoreSchema>;
 type StaffFormValues = z.infer<typeof staffCollateralSchema>;
 type FormValues = CoreFormValues & { financier_id?: number };
 
+function ReadOnlyField({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="space-y-1">
+      <label className="text-xs font-medium text-slate-700">{label}</label>
+      <div className="flex h-8 w-full items-center rounded-sm border border-slate-200 bg-slate-50 px-2.5 text-sm text-slate-800">
+        {value || '—'}
+      </div>
+    </div>
+  );
+}
+
 interface CollateralFormProps {
   initial?: Partial<FormValues>;
   financierDisplayLabel?: string;
@@ -79,6 +94,10 @@ interface CollateralFormProps {
   onSuccessAndAddAnother?: () => void;
   isEdit?: boolean;
   recordId?: number;
+  /** Edit mode only: invoked when "Close" is clicked, to discharge the record. */
+  onDischarge?: () => void;
+  /** Edit mode only: loading state for the discharge action. */
+  dischargePending?: boolean;
 }
 
 export function CollateralForm({
@@ -92,6 +111,8 @@ export function CollateralForm({
   onSuccessAndAddAnother,
   isEdit,
   recordId,
+  onDischarge,
+  dischargePending,
 }: CollateralFormProps) {
   const user = useAuthStore((s) => s.user);
   const setUser = useAuthStore((s) => s.setUser);
@@ -116,11 +137,25 @@ export function CollateralForm({
   const isFirstFinancierClientTypeRender = useRef(true);
   const [debtorLabel, setDebtorLabel] = useState(debtorDisplayLabel ?? '');
   const isFirstDebtorTypeRender = useRef(true);
+  const [dataSourceUserId, setDataSourceUserId] = useState<
+    number | undefined
+  >();
+  const [staffDataSourceName, setStaffDataSourceName] = useState('');
+  const [staffDataSourcePosition, setStaffDataSourcePosition] = useState('');
+  const [staffDataSourceSearchLabel, setStaffDataSourceSearchLabel] =
+    useState('');
+
+  const clearDataSource = () => {
+    setDataSourceUserId(undefined);
+    setStaffDataSourceName('');
+    setStaffDataSourcePosition('');
+    setStaffDataSourceSearchLabel('');
+  };
 
   const { register, handleSubmit, control, watch, setError, setValue } =
     useForm<FormValues>({
       resolver: zodResolver(formSchema),
-      mode: 'onSubmit',
+      mode: 'onBlur',
       reValidateMode: 'onChange',
       shouldFocusError: true,
       defaultValues: {
@@ -131,9 +166,7 @@ export function CollateralForm({
         total_paid_to_date: 0,
         instalment_amount: 0,
         instalment_date: 1,
-        ...(isClientUser
-          ? {}
-          : { financier_id: clientFinancierId }),
+        ...(isClientUser ? {} : { financier_id: clientFinancierId }),
         ...initial,
       },
     });
@@ -153,6 +186,28 @@ export function CollateralForm({
   const partyTypeOptions = choices.PartyType ?? [];
   const assetTypeOptions = choices.CollateralAssetType ?? [];
   const assetConditionOptions = choices.AssetCondition ?? [];
+  const selectedFinancierId = watch('financier_id');
+
+  const { data: clientUsers = [] } = useQuery({
+    queryKey: ['collateral-client-users', selectedFinancierId],
+    queryFn: () => clientsApi.listClientUsers(Number(selectedFinancierId)),
+    enabled:
+      !isEdit &&
+      isStaff &&
+      !!selectedFinancierId &&
+      Number(selectedFinancierId) > 0,
+  });
+
+  const { data: clientDetail } = useQuery({
+    queryKey: ['collateral-client-detail', selectedFinancierId],
+    queryFn: () => clientsApi.getClient(Number(selectedFinancierId)),
+    enabled:
+      !isEdit &&
+      isStaff &&
+      financierClientType === 'individual' &&
+      !!selectedFinancierId &&
+      Number(selectedFinancierId) > 0,
+  });
 
   useEffect(() => {
     if (!watch('currency') && currencies.length > 0) {
@@ -179,7 +234,10 @@ export function CollateralForm({
 
   useEffect(() => {
     if (isStaff || user?.client_id) return;
-    void authApi.me().then(setUser).catch(() => {});
+    void authApi
+      .me()
+      .then(setUser)
+      .catch(() => {});
   }, [isStaff, user?.client_id, setUser]);
 
   useEffect(() => {
@@ -197,7 +255,7 @@ export function CollateralForm({
   ]);
 
   useEffect(() => {
-    if (isClientUser) return;
+    if (isClientUser || isEdit) return;
     if (isFirstFinancierClientTypeRender.current) {
       isFirstFinancierClientTypeRender.current = false;
       return;
@@ -205,10 +263,46 @@ export function CollateralForm({
     setValue('financier_id', 0 as unknown as number);
     setFinancierLabel('');
     setAddClientOpen(false);
-  }, [financierClientType, isClientUser, setValue]);
+  }, [financierClientType, isClientUser, isEdit, setValue]);
+
+  useEffect(() => {
+    if (isEdit || isClientUser) return;
+    clearDataSource();
+  }, [selectedFinancierId, isEdit, isClientUser]);
+
+  useEffect(() => {
+    if (
+      isEdit ||
+      !isStaff ||
+      financierClientType !== 'individual' ||
+      !clientDetail
+    ) {
+      return;
+    }
+    const details = clientDetail.client_details;
+    const individualName =
+      (details?.full_name ??
+        `${details?.first_name ?? ''} ${details?.last_name ?? ''}`.trim()) ||
+      clientDetail.name;
+    setStaffDataSourceName(individualName);
+    setStaffDataSourceSearchLabel(individualName);
+    setStaffDataSourcePosition('');
+  }, [clientDetail, financierClientType, isEdit, isStaff]);
+
+  useEffect(() => {
+    if (isEdit || !isStaff || financierClientType !== 'individual') return;
+    if (clientUsers.length === 1) {
+      const linkedUser = clientUsers[0];
+      setDataSourceUserId(linkedUser.id);
+      if (linkedUser.position) {
+        setStaffDataSourcePosition(linkedUser.position);
+      }
+    }
+  }, [clientUsers, financierClientType, isEdit, isStaff]);
 
   const watchedDebtorType = watch('debtor_type');
   useEffect(() => {
+    if (isEdit) return;
     if (isFirstDebtorTypeRender.current) {
       isFirstDebtorTypeRender.current = false;
       return;
@@ -217,7 +311,24 @@ export function CollateralForm({
     setDebtorLabel('');
     setAddIndividualOpen(false);
     setAddCompanyOpen(false);
-  }, [watchedDebtorType, setValue]);
+  }, [watchedDebtorType, isEdit, setValue]);
+
+  useEffect(() => {
+    if (debtorDisplayLabel) {
+      setDebtorLabel(debtorDisplayLabel);
+    }
+  }, [debtorDisplayLabel]);
+
+  useEffect(() => {
+    if (financierDisplayLabel) {
+      setFinancierLabel(financierDisplayLabel);
+    }
+  }, [financierDisplayLabel]);
+
+  const debtorTypeLabel =
+    partyTypeOptions.find(
+      (option: { value: string }) => option.value === watchedDebtorType,
+    )?.label ?? watchedDebtorType;
 
   const watchedAssetType = watch('asset_type');
   const isVehicle = watchedAssetType === 'vehicles';
@@ -225,6 +336,8 @@ export function CollateralForm({
     (watch('loan_amount') ?? 0) - (watch('total_paid_to_date') ?? 0);
 
   const [addAnother, setAddAnother] = useState(false);
+  const [confirmingUpdate, setConfirmingUpdate] = useState(false);
+  const [pendingSubmit, setPendingSubmit] = useState<FormValues | null>(null);
 
   const { mutate: submit, isPending } = useMutation({
     mutationFn: (data: FormValues) =>
@@ -232,6 +345,8 @@ export function CollateralForm({
         ? collateralApi.updateRecord(recordId, data as any)
         : collateralApi.createRecord(data as any),
     onSuccess: () => {
+      setConfirmingUpdate(false);
+      setPendingSubmit(null);
       if (addAnother && onSuccessAndAddAnother) {
         onSuccessAndAddAnother();
       } else {
@@ -239,6 +354,7 @@ export function CollateralForm({
       }
     },
     onError: (err: unknown) => {
+      setConfirmingUpdate(false);
       setAddAnother(false);
       if (!applyApiValidationErrors(setError, err)) {
         const data = (
@@ -254,31 +370,111 @@ export function CollateralForm({
   const onInvalid = (formErrors: FieldErrors<FormValues>) => {
     setAddAnother(false);
     toast.error(
-      firstFormErrorMessage(formErrors) ??
-        'Please fix the highlighted fields',
+      firstFormErrorMessage(formErrors) ?? 'Please fix the highlighted fields',
     );
   };
 
+  const buildSubmitPayload = (data: FormValues) => {
+    const payload = isClientUser
+      ? ({ ...data, financier_id: clientFinancierId } as StaffFormValues)
+      : (data as StaffFormValues);
+
+    if (isStaff && !isEdit && dataSourceUserId) {
+      return { ...payload, data_source_user_id: dataSourceUserId };
+    }
+    return payload;
+  };
+
+  const performSubmit = (data: FormValues) => {
+    submit(buildSubmitPayload(data) as any);
+  };
+
+  const validateStaffDataSource = () => {
+    if (
+      !isStaff ||
+      isEdit ||
+      !selectedFinancierId ||
+      Number(selectedFinancierId) <= 0
+    ) {
+      return true;
+    }
+    if (financierClientType === 'company' && !dataSourceUserId) {
+      toast.error(
+        'Please select a data source user for this company financier.',
+      );
+      return false;
+    }
+    return true;
+  };
+
   const onFormSubmit = handleSubmit((data) => {
-    if (isClientUser) {
-      if (!clientFinancierId) {
-        toast.error(
-          'Unable to load your financier profile. Please refresh and try again.',
-        );
-        return;
-      }
-      submit({ ...data, financier_id: clientFinancierId } as StaffFormValues);
+    if (isClientUser && !clientFinancierId) {
+      toast.error(
+        'Unable to load your financier profile. Please refresh and try again.',
+      );
       return;
     }
-    submit(data as StaffFormValues);
+    if (!validateStaffDataSource()) return;
+    if (isEdit) {
+      setPendingSubmit(data);
+      setConfirmingUpdate(true);
+      return;
+    }
+    performSubmit(data);
   }, onInvalid);
+
+  const handleConfirmUpdate = () => {
+    if (pendingSubmit) {
+      performSubmit(pendingSubmit);
+    }
+  };
 
   return (
     <>
       <form onSubmit={onFormSubmit} className="bg-white" noValidate>
         {/* ── Financier Section ── */}
         <FormSectionHeader title="Financier" variant="teal" />
-        {isClientUser ? (
+        {isEdit ? (
+          <>
+            <div className="grid grid-cols-2 gap-3 p-4 pb-2 sm:grid-cols-4">
+              <div className="col-span-2">
+                <ReadOnlyField
+                  label="Financier Name"
+                  value={financierLabel || financierDisplayLabel || ''}
+                />
+              </div>
+              <Controller
+                name="data_date"
+                control={control}
+                render={({ field, fieldState }) => (
+                  <DateInput
+                    label="Data Date"
+                    value={field.value}
+                    onChange={field.onChange}
+                    onBlur={field.onBlur}
+                    error={fieldState.error?.message}
+                    required
+                    disabled
+                  />
+                )}
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-3 px-4 pb-4 sm:grid-cols-4">
+              <div className="col-span-2">
+                <ReadOnlyField
+                  label="Data Source Name"
+                  value={dataSourceDisplayLabel ?? user?.name ?? ''}
+                />
+              </div>
+              <div className="col-span-2">
+                <ReadOnlyField
+                  label="Position"
+                  value={dataSourcePositionLabel ?? user?.position ?? ''}
+                />
+              </div>
+            </div>
+          </>
+        ) : isClientUser ? (
           <>
             <div className="grid grid-cols-2 gap-3 p-4 pb-2 sm:grid-cols-4">
               <div className="col-span-2 space-y-1">
@@ -308,6 +504,7 @@ export function CollateralForm({
                     onBlur={field.onBlur}
                     error={fieldState.error?.message}
                     required
+                    disabled
                   />
                 )}
               />
@@ -318,9 +515,7 @@ export function CollateralForm({
                   Data Source Name
                 </label>
                 <div className="flex h-8 w-full items-center rounded-sm border border-slate-200 bg-slate-50 px-2.5 text-sm text-slate-800">
-                  {isEdit
-                    ? (dataSourceDisplayLabel ?? user?.name ?? '—')
-                    : (user?.name ?? '—')}
+                  {user?.name ?? '—'}
                 </div>
               </div>
               <div className="col-span-2 space-y-1">
@@ -328,9 +523,7 @@ export function CollateralForm({
                   Position
                 </label>
                 <div className="flex h-8 w-full items-center rounded-sm border border-slate-200 bg-slate-50 px-2.5 text-sm text-slate-800">
-                  {isEdit
-                    ? (dataSourcePositionLabel ?? user?.position ?? '—')
-                    : (user?.position ?? '—')}
+                  {user?.position ?? '—'}
                 </div>
               </div>
             </div>
@@ -397,10 +590,61 @@ export function CollateralForm({
                     onBlur={field.onBlur}
                     error={fieldState.error?.message}
                     required
+                    disabled
                   />
                 )}
               />
             </div>
+            {selectedFinancierId && Number(selectedFinancierId) > 0 ? (
+              <div className="grid grid-cols-2 gap-3 px-4 pb-4 sm:grid-cols-4">
+                <div className="col-span-2">
+                  {financierClientType === 'company' ? (
+                    <AutocompleteInput
+                      label="Data Source Name"
+                      placeholder="Search user under client..."
+                      queryKey={`collateral-data-source-${selectedFinancierId}`}
+                      displayLabel={staffDataSourceSearchLabel}
+                      minChars={1}
+                      fetchFn={async (q) => {
+                        const term = q.trim().toLowerCase();
+                        if (!term) return [];
+                        return clientUsers
+                          .filter(
+                            (u) =>
+                              u.name.toLowerCase().includes(term) ||
+                              (u.position?.toLowerCase().includes(term) ??
+                                false),
+                          )
+                          .map((u) => ({
+                            id: u.id,
+                            name: u.name,
+                            subtitle: u.position,
+                          }));
+                      }}
+                      value={dataSourceUserId}
+                      onChange={(id) => {
+                        const selected = clientUsers.find((u) => u.id === id);
+                        setDataSourceUserId(id);
+                        setStaffDataSourceName(selected?.name ?? '');
+                        setStaffDataSourcePosition(selected?.position ?? '');
+                        setStaffDataSourceSearchLabel(selected?.name ?? '');
+                      }}
+                    />
+                  ) : (
+                    <ReadOnlyField
+                      label="Data Source Name"
+                      value={staffDataSourceName}
+                    />
+                  )}
+                </div>
+                <div className="col-span-2">
+                  <ReadOnlyField
+                    label="Position"
+                    value={staffDataSourcePosition}
+                  />
+                </div>
+              </div>
+            ) : null}
             {isStaff && (
               <div className="flex gap-2 px-4 pb-4">
                 <Button
@@ -419,70 +663,84 @@ export function CollateralForm({
 
         {/* ── Debtor Section ── */}
         <FormSectionHeader title="Debtor" variant="teal" />
-        <div className="flex gap-2 px-4 pt-2 pb-1">
-          <Button
-            type="button"
-            size="sm"
-            variant="primary"
-            leftIcon={<UserPlus className="h-3 w-3" />}
-            onClick={() => setAddIndividualOpen(true)}
-          >
-            + Add Individual
-          </Button>
-          <Button
-            type="button"
-            size="sm"
-            variant="secondary"
-            leftIcon={<Building className="h-3 w-3" />}
-            onClick={() => setAddCompanyOpen(true)}
-          >
-            + Add Company
-          </Button>
-        </div>
-        <div className="grid grid-cols-2 gap-3 p-4 sm:grid-cols-4">
-          <div>
-            <label className="text-xs font-medium text-slate-600">
-              Debtor Type
-            </label>
-            <select
-              {...register('debtor_type')}
-              className="mt-1 h-8 w-full rounded border border-slate-300 bg-white px-2 text-sm focus:outline-none focus:border-[#0f7d8e]"
-              disabled={!partyTypeOptions.length}
+        {!isEdit && (
+          <div className="flex gap-2 px-4 pt-2 pb-1">
+            <Button
+              type="button"
+              size="sm"
+              variant="primary"
+              leftIcon={<UserPlus className="h-3 w-3" />}
+              onClick={() => setAddIndividualOpen(true)}
             >
-              <option value="">
-                {partyTypeOptions.length ? 'Select type...' : 'Loading...'}
-              </option>
-              {partyTypeOptions.map((option: any) => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
+              + Add Individual
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="secondary"
+              leftIcon={<Building className="h-3 w-3" />}
+              onClick={() => setAddCompanyOpen(true)}
+            >
+              + Add Company
+            </Button>
+          </div>
+        )}
+        {isEdit ? (
+          <div className="grid grid-cols-2 gap-3 p-4 sm:grid-cols-4">
+            <ReadOnlyField label="Debtor Type" value={debtorTypeLabel} />
+            <div className="col-span-3">
+              <ReadOnlyField
+                label="Debtor"
+                value={debtorLabel || debtorDisplayLabel || ''}
+              />
+            </div>
+          </div>
+        ) : (
+          <div className="grid grid-cols-2 gap-3 p-4 sm:grid-cols-4">
+            <div>
+              <label className="text-xs font-medium text-slate-600">
+                Debtor Type
+              </label>
+              <select
+                {...register('debtor_type')}
+                className="mt-1 h-8 w-full rounded border border-slate-300 bg-white px-2 text-sm focus:outline-none focus:border-[#0f7d8e]"
+                disabled={!partyTypeOptions.length}
+              >
+                <option value="">
+                  {partyTypeOptions.length ? 'Select type...' : 'Loading...'}
                 </option>
-              ))}
-            </select>
+                {partyTypeOptions.map((option: any) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="col-span-3">
+              <Controller
+                name="debtor_id"
+                control={control}
+                render={({ field }) => (
+                  <AutocompleteInput
+                    label="Name / ID / Reg. No."
+                    placeholder="Search debtor..."
+                    queryKey={`collateral-debtor-${watch('debtor_type')}`}
+                    displayLabel={debtorLabel}
+                    fetchFn={(q) =>
+                      watch('debtor_type') === 'company'
+                        ? companiesApi.searchBranches(q)
+                        : individualsApi.searchIndividuals(q)
+                    }
+                    error={errors.debtor_id?.message}
+                    value={field.value}
+                    onBlur={field.onBlur}
+                    onChange={(v) => field.onChange(Number(v))}
+                  />
+                )}
+              />
+            </div>
           </div>
-          <div className="col-span-3">
-            <Controller
-              name="debtor_id"
-              control={control}
-              render={({ field }) => (
-                <AutocompleteInput
-                  label="Name / ID / Reg. No."
-                  placeholder="Search debtor..."
-                  queryKey={`collateral-debtor-${watch('debtor_type')}`}
-                  displayLabel={debtorLabel}
-                  fetchFn={(q) =>
-                    watch('debtor_type') === 'company'
-                      ? companiesApi.searchBranches(q)
-                      : individualsApi.searchIndividuals(q)
-                  }
-                  error={errors.debtor_id?.message}
-                  value={field.value}
-                  onBlur={field.onBlur}
-                  onChange={(v) => field.onChange(Number(v))}
-                />
-              )}
-            />
-          </div>
-        </div>
+        )}
 
         {/* ── Agreement & Asset Details ── */}
         <FormSectionHeader title="Agreement & Asset Details" variant="dark" />
@@ -664,34 +922,53 @@ export function CollateralForm({
 
         {/* ── Footer ── */}
         <div className="flex items-center justify-between border-t border-slate-200 bg-slate-50 px-4 py-3">
-          <Button type="button" variant="ghost" onClick={onCancel}>
-            {onSuccessAndAddAnother ? 'Done' : 'Cancel'}
-          </Button>
-          <div className="flex gap-2">
-            {onSuccessAndAddAnother && !isEdit && (
+          {isEdit ? (
+            <>
               <Button
                 type="submit"
                 variant="secondary"
-                loading={isPending && addAnother}
-                disabled={isPending && !addAnother}
-                onClick={() => setAddAnother(true)}
+                loading={isPending}
+                onClick={() => setAddAnother(false)}
               >
-                Save & Add Another
+                Update
               </Button>
-            )}
-            <Button
-              type="submit"
-              loading={isPending && !addAnother}
-              disabled={isPending && addAnother}
-              onClick={() => setAddAnother(false)}
-            >
-              {isEdit
-                ? 'Save Changes'
-                : onSuccessAndAddAnother
-                  ? 'Save'
-                  : 'Upload'}
-            </Button>
-          </div>
+              <Button
+                type="button"
+                variant="danger"
+                loading={dischargePending}
+                onClick={onDischarge}
+              >
+                Close
+              </Button>
+            </>
+          ) : (
+            <>
+              <Button type="button" variant="ghost" onClick={onCancel}>
+                {onSuccessAndAddAnother ? 'Done' : 'Cancel'}
+              </Button>
+              <div className="flex gap-2">
+                {onSuccessAndAddAnother && (
+                  <Button
+                    type="submit"
+                    variant="secondary"
+                    loading={isPending && addAnother}
+                    disabled={isPending && !addAnother}
+                    onClick={() => setAddAnother(true)}
+                  >
+                    Save & Add Another
+                  </Button>
+                )}
+                <Button
+                  type="submit"
+                  loading={isPending && !addAnother}
+                  disabled={isPending && addAnother}
+                  onClick={() => setAddAnother(false)}
+                >
+                  {onSuccessAndAddAnother ? 'Save' : 'Upload'}
+                </Button>
+              </div>
+            </>
+          )}
         </div>
       </form>
 
@@ -746,6 +1023,20 @@ export function CollateralForm({
           }}
         />
       </Modal>
+
+      <ConfirmDialog
+        open={confirmingUpdate}
+        title="Confirm Update"
+        message="Are you sure you want to save these changes?"
+        confirmLabel="Yes, Update"
+        variant="primary"
+        loading={isPending}
+        onConfirm={handleConfirmUpdate}
+        onCancel={() => {
+          setConfirmingUpdate(false);
+          setPendingSubmit(null);
+        }}
+      />
     </>
   );
 }

--- a/frontend/src/components/collateral/CollateralForm.tsx
+++ b/frontend/src/components/collateral/CollateralForm.tsx
@@ -1,28 +1,34 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useForm, useFormState, Controller } from 'react-hook-form';
 import { zodResolver } from '@/lib/zodResolver';
-import { applyApiValidationErrors } from '@/lib/formErrors';
+import { applyApiValidationErrors, firstFormErrorMessage } from '@/lib/formErrors';
+import type { FieldErrors } from 'react-hook-form';
 import { z } from 'zod';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { toast } from 'sonner';
+import { UserPlus, Building } from 'lucide-react';
 import { collateralApi } from '@/api/collateralApi';
+import { clientsApi } from '@/api/clientsApi';
 import { individualsApi } from '@/api/individualsApi';
 import { companiesApi } from '@/api/companiesApi';
-import { clientsApi } from '@/api/clientsApi';
 import { Input } from '@/components/ui/input';
 import { DateInput } from '@/components/ui/DateInput';
 import AutocompleteInput from '@/components/shared/AutocompleteInput';
 import { Button } from '@/components/ui/button';
 import { FormSectionHeader } from '@/components/shared/FormSectionHeader';
 import { FieldError } from '@/components/shared/FieldError';
+import { Modal } from '@/components/shared/Modal';
+import { IndividualCreateForm } from '@/components/individuals/IndividualCreateForm';
+import { CompanyCreateForm } from '@/components/companies/CompanyCreateForm';
+import { ClientCreateForm } from '@/components/clients/ClientCreateForm';
 import { commonApi } from '@/api/commonApi';
 import { queryOptions } from '@/api/queryOptions';
+import { useAuthStore } from '@/store';
+import { isStaffUser } from '@/lib/registryNav';
+import { cn } from '@/lib/utils';
+import { authApi } from '@/api/authApi';
 
-const schema = z.object({
-  financier_type: z.string().min(1, 'Financier Type is required'),
-  financier_id: z
-    .number({ error: 'Financier is required' })
-    .min(1, 'Financier is required'),
+const collateralCoreSchema = z.object({
   data_date: z.string().min(1, 'Required'),
   debtor_type: z.string().min(1, 'Debtor Type is required'),
   debtor_id: z
@@ -47,14 +53,30 @@ const schema = z.object({
   end_date: z.string().min(1),
 });
 
-type FormValues = z.infer<typeof schema>;
+const staffCollateralSchema = collateralCoreSchema.extend({
+  financier_id: z
+    .number({ error: 'Financier is required' })
+    .min(1, 'Financier is required'),
+});
+
+function buildCollateralSchema(isClientUser: boolean) {
+  return isClientUser ? collateralCoreSchema : staffCollateralSchema;
+}
+
+type CoreFormValues = z.infer<typeof collateralCoreSchema>;
+type StaffFormValues = z.infer<typeof staffCollateralSchema>;
+type FormValues = CoreFormValues & { financier_id?: number };
 
 interface CollateralFormProps {
   initial?: Partial<FormValues>;
   financierDisplayLabel?: string;
+  dataSourceDisplayLabel?: string;
+  dataSourcePositionLabel?: string;
   debtorDisplayLabel?: string;
   onSuccess: () => void;
   onCancel: () => void;
+  /** When true shows "Save & Add Another" instead of "Upload" */
+  onSuccessAndAddAnother?: () => void;
   isEdit?: boolean;
   recordId?: number;
 }
@@ -62,25 +84,56 @@ interface CollateralFormProps {
 export function CollateralForm({
   initial,
   financierDisplayLabel,
+  dataSourceDisplayLabel,
+  dataSourcePositionLabel,
   debtorDisplayLabel,
   onSuccess,
   onCancel,
+  onSuccessAndAddAnother,
   isEdit,
   recordId,
 }: CollateralFormProps) {
+  const user = useAuthStore((s) => s.user);
+  const setUser = useAuthStore((s) => s.setUser);
+  const isStaff = isStaffUser(user);
+  const isClientUser = !isStaff && !!user;
+  const clientFinancierId = user?.client_id;
+
+  const formSchema = useMemo(
+    () => buildCollateralSchema(isClientUser),
+    [isClientUser],
+  );
+
+  const [addIndividualOpen, setAddIndividualOpen] = useState(false);
+  const [addCompanyOpen, setAddCompanyOpen] = useState(false);
+  const [addClientOpen, setAddClientOpen] = useState(false);
+  const [financierLabel, setFinancierLabel] = useState(
+    financierDisplayLabel ?? '',
+  );
+  const [financierClientType, setFinancierClientType] = useState<
+    'individual' | 'company'
+  >('company');
+  const isFirstFinancierClientTypeRender = useRef(true);
+  const [debtorLabel, setDebtorLabel] = useState(debtorDisplayLabel ?? '');
+  const isFirstDebtorTypeRender = useRef(true);
+
   const { register, handleSubmit, control, watch, setError, setValue } =
     useForm<FormValues>({
-      resolver: zodResolver(schema),
+      resolver: zodResolver(formSchema),
       mode: 'onSubmit',
       reValidateMode: 'onChange',
       shouldFocusError: true,
       defaultValues: {
-        financier_type: 'company',
         debtor_type: 'individual',
         data_date: new Date().toISOString().split('T')[0],
         currency: '',
         asset_year: new Date().getFullYear(),
         total_paid_to_date: 0,
+        instalment_amount: 0,
+        instalment_date: 1,
+        ...(isClientUser
+          ? {}
+          : { financier_id: clientFinancierId }),
         ...initial,
       },
     });
@@ -116,14 +169,6 @@ export function CollateralForm({
   }, [assetConditionOptions, setValue, watch]);
 
   useEffect(() => {
-    if (!watch('financier_type') && partyTypeOptions.length > 0) {
-      const defaultFinancier =
-        partyTypeOptions.find((p: any) => p.value === 'company') ||
-        partyTypeOptions[0];
-      setValue('financier_type', defaultFinancier.value, {
-        shouldValidate: true,
-      });
-    }
     if (!watch('debtor_type') && partyTypeOptions.length > 0) {
       const defaultDebtor =
         partyTypeOptions.find((p: any) => p.value === 'individual') ||
@@ -132,18 +177,69 @@ export function CollateralForm({
     }
   }, [partyTypeOptions, setValue, watch]);
 
+  useEffect(() => {
+    if (isStaff || user?.client_id) return;
+    void authApi.me().then(setUser).catch(() => {});
+  }, [isStaff, user?.client_id, setUser]);
+
+  useEffect(() => {
+    if (!isClientUser || !clientFinancierId) return;
+    if (financierDisplayLabel) {
+      setFinancierLabel(financierDisplayLabel);
+    } else {
+      setFinancierLabel(user?.client_name ?? '');
+    }
+  }, [
+    isClientUser,
+    clientFinancierId,
+    user?.client_name,
+    financierDisplayLabel,
+  ]);
+
+  useEffect(() => {
+    if (isClientUser) return;
+    if (isFirstFinancierClientTypeRender.current) {
+      isFirstFinancierClientTypeRender.current = false;
+      return;
+    }
+    setValue('financier_id', 0 as unknown as number);
+    setFinancierLabel('');
+    setAddClientOpen(false);
+  }, [financierClientType, isClientUser, setValue]);
+
+  const watchedDebtorType = watch('debtor_type');
+  useEffect(() => {
+    if (isFirstDebtorTypeRender.current) {
+      isFirstDebtorTypeRender.current = false;
+      return;
+    }
+    setValue('debtor_id', 0 as unknown as number);
+    setDebtorLabel('');
+    setAddIndividualOpen(false);
+    setAddCompanyOpen(false);
+  }, [watchedDebtorType, setValue]);
+
   const watchedAssetType = watch('asset_type');
   const isVehicle = watchedAssetType === 'vehicles';
   const computedBalance =
     (watch('loan_amount') ?? 0) - (watch('total_paid_to_date') ?? 0);
+
+  const [addAnother, setAddAnother] = useState(false);
 
   const { mutate: submit, isPending } = useMutation({
     mutationFn: (data: FormValues) =>
       isEdit && recordId
         ? collateralApi.updateRecord(recordId, data as any)
         : collateralApi.createRecord(data as any),
-    onSuccess,
+    onSuccess: () => {
+      if (addAnother && onSuccessAndAddAnother) {
+        onSuccessAndAddAnother();
+      } else {
+        onSuccess();
+      }
+    },
     onError: (err: unknown) => {
+      setAddAnother(false);
       if (!applyApiValidationErrors(setError, err)) {
         const data = (
           err as { response?: { data?: { message?: string; error?: string } } }
@@ -155,302 +251,501 @@ export function CollateralForm({
     },
   });
 
-  const onInvalid = () => {
-    toast.error('Please fix the highlighted fields');
+  const onInvalid = (formErrors: FieldErrors<FormValues>) => {
+    setAddAnother(false);
+    toast.error(
+      firstFormErrorMessage(formErrors) ??
+        'Please fix the highlighted fields',
+    );
   };
 
+  const onFormSubmit = handleSubmit((data) => {
+    if (isClientUser) {
+      if (!clientFinancierId) {
+        toast.error(
+          'Unable to load your financier profile. Please refresh and try again.',
+        );
+        return;
+      }
+      submit({ ...data, financier_id: clientFinancierId } as StaffFormValues);
+      return;
+    }
+    submit(data as StaffFormValues);
+  }, onInvalid);
+
   return (
-    <form
-      onSubmit={handleSubmit((d) => submit(d), onInvalid)}
-      className="bg-white"
-      noValidate
-    >
-      {/* ── Financier Section ── */}
-      <FormSectionHeader title="Financier" variant="teal" />
-      <div className="grid grid-cols-2 gap-3 p-4 sm:grid-cols-4">
-        <div>
-          <label className="text-xs font-medium text-slate-600">
-            Financier Type
-          </label>
-          <select
-            {...register('financier_type')}
-            className="mt-1 h-8 w-full rounded border border-slate-300 bg-white px-2 text-sm focus:outline-none focus:border-[#0f7d8e]"
-            disabled={!partyTypeOptions.length}
-          >
-            <option value="">
-              {partyTypeOptions.length ? 'Select type...' : 'Loading...'}
-            </option>
-            {partyTypeOptions.map((option: any) => (
-              <option key={option.value} value={option.value}>
-                {option.label}
-              </option>
-            ))}
-          </select>
-        </div>
-        <div className="col-span-2">
-          <Controller
-            name="financier_id"
-            control={control}
-            render={({ field }) => (
-              <AutocompleteInput
-                label="Name / ID / Reg. No."
-                placeholder="Search financier..."
-                queryKey="collateral-financier"
-                displayLabel={financierDisplayLabel}
-                fetchFn={clientsApi.searchClients}
-                error={errors.financier_id?.message}
-                value={field.value}
-                onBlur={field.onBlur}
-                onChange={(v) => field.onChange(Number(v))}
+    <>
+      <form onSubmit={onFormSubmit} className="bg-white" noValidate>
+        {/* ── Financier Section ── */}
+        <FormSectionHeader title="Financier" variant="teal" />
+        {isClientUser ? (
+          <>
+            <div className="grid grid-cols-2 gap-3 p-4 pb-2 sm:grid-cols-4">
+              <div className="col-span-2 space-y-1">
+                <label className="text-xs font-medium text-slate-700">
+                  Financier Name
+                </label>
+                <div
+                  className={cn(
+                    'flex h-8 w-full items-center rounded-sm border bg-slate-50 px-2.5 text-sm text-slate-800',
+                    !clientFinancierId ? 'border-red-500' : 'border-slate-200',
+                  )}
+                >
+                  {financierLabel || user?.client_name || '—'}
+                </div>
+                {!clientFinancierId && (
+                  <FieldError message="Financier profile not loaded. Please refresh the page." />
+                )}
+              </div>
+              <Controller
+                name="data_date"
+                control={control}
+                render={({ field, fieldState }) => (
+                  <DateInput
+                    label="Data Date"
+                    value={field.value}
+                    onChange={field.onChange}
+                    onBlur={field.onBlur}
+                    error={fieldState.error?.message}
+                    required
+                  />
+                )}
               />
+            </div>
+            <div className="grid grid-cols-2 gap-3 px-4 pb-4 sm:grid-cols-4">
+              <div className="col-span-2 space-y-1">
+                <label className="text-xs font-medium text-slate-700">
+                  Data Source Name
+                </label>
+                <div className="flex h-8 w-full items-center rounded-sm border border-slate-200 bg-slate-50 px-2.5 text-sm text-slate-800">
+                  {isEdit
+                    ? (dataSourceDisplayLabel ?? user?.name ?? '—')
+                    : (user?.name ?? '—')}
+                </div>
+              </div>
+              <div className="col-span-2 space-y-1">
+                <label className="text-xs font-medium text-slate-700">
+                  Position
+                </label>
+                <div className="flex h-8 w-full items-center rounded-sm border border-slate-200 bg-slate-50 px-2.5 text-sm text-slate-800">
+                  {isEdit
+                    ? (dataSourcePositionLabel ?? user?.position ?? '—')
+                    : (user?.position ?? '—')}
+                </div>
+              </div>
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="grid grid-cols-2 gap-3 p-4 pb-2 sm:grid-cols-4">
+              <div className="space-y-1">
+                <label className="text-xs font-medium text-slate-700">
+                  Financier Type
+                </label>
+                <select
+                  value={financierClientType}
+                  onChange={(e) =>
+                    setFinancierClientType(
+                      e.target.value as 'individual' | 'company',
+                    )
+                  }
+                  className="h-8 w-full rounded-sm border border-slate-500 bg-white px-2.5 text-sm text-slate-900 focus:border-black focus:outline-none focus:ring-0"
+                  disabled={!partyTypeOptions.length}
+                >
+                  {partyTypeOptions.length === 0 ? (
+                    <option value="company">Loading...</option>
+                  ) : (
+                    partyTypeOptions.map((option: any) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))
+                  )}
+                </select>
+              </div>
+              <div className="col-span-2">
+                <Controller
+                  name="financier_id"
+                  control={control}
+                  render={({ field }) => (
+                    <AutocompleteInput
+                      label="Financier Name"
+                      placeholder="Search financier..."
+                      queryKey={`collateral-financier-${financierClientType}`}
+                      displayLabel={financierLabel}
+                      fetchFn={(q) =>
+                        clientsApi.searchClients(q, {
+                          entityType: financierClientType,
+                        })
+                      }
+                      error={errors.financier_id?.message}
+                      value={field.value}
+                      onBlur={field.onBlur}
+                      onChange={(v) => field.onChange(Number(v))}
+                    />
+                  )}
+                />
+              </div>
+              <Controller
+                name="data_date"
+                control={control}
+                render={({ field, fieldState }) => (
+                  <DateInput
+                    label="Data Date"
+                    value={field.value}
+                    onChange={field.onChange}
+                    onBlur={field.onBlur}
+                    error={fieldState.error?.message}
+                    required
+                  />
+                )}
+              />
+            </div>
+            {isStaff && (
+              <div className="flex gap-2 px-4 pb-4">
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="secondary"
+                  leftIcon={<UserPlus className="h-3 w-3" />}
+                  onClick={() => setAddClientOpen(true)}
+                >
+                  + Add Client
+                </Button>
+              </div>
             )}
-          />
+          </>
+        )}
+
+        {/* ── Debtor Section ── */}
+        <FormSectionHeader title="Debtor" variant="teal" />
+        <div className="flex gap-2 px-4 pt-2 pb-1">
+          <Button
+            type="button"
+            size="sm"
+            variant="primary"
+            leftIcon={<UserPlus className="h-3 w-3" />}
+            onClick={() => setAddIndividualOpen(true)}
+          >
+            + Add Individual
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="secondary"
+            leftIcon={<Building className="h-3 w-3" />}
+            onClick={() => setAddCompanyOpen(true)}
+          >
+            + Add Company
+          </Button>
         </div>
-        <Controller
-          name="data_date"
-          control={control}
-          render={({ field, fieldState }) => (
-            <DateInput
-              label="Data Date"
-              value={field.value}
-              onChange={field.onChange}
-              onBlur={field.onBlur}
-              error={fieldState.error?.message}
-              required
+        <div className="grid grid-cols-2 gap-3 p-4 sm:grid-cols-4">
+          <div>
+            <label className="text-xs font-medium text-slate-600">
+              Debtor Type
+            </label>
+            <select
+              {...register('debtor_type')}
+              className="mt-1 h-8 w-full rounded border border-slate-300 bg-white px-2 text-sm focus:outline-none focus:border-[#0f7d8e]"
+              disabled={!partyTypeOptions.length}
+            >
+              <option value="">
+                {partyTypeOptions.length ? 'Select type...' : 'Loading...'}
+              </option>
+              {partyTypeOptions.map((option: any) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="col-span-3">
+            <Controller
+              name="debtor_id"
+              control={control}
+              render={({ field }) => (
+                <AutocompleteInput
+                  label="Name / ID / Reg. No."
+                  placeholder="Search debtor..."
+                  queryKey={`collateral-debtor-${watch('debtor_type')}`}
+                  displayLabel={debtorLabel}
+                  fetchFn={(q) =>
+                    watch('debtor_type') === 'company'
+                      ? companiesApi.searchBranches(q)
+                      : individualsApi.searchIndividuals(q)
+                  }
+                  error={errors.debtor_id?.message}
+                  value={field.value}
+                  onBlur={field.onBlur}
+                  onChange={(v) => field.onChange(Number(v))}
+                />
+              )}
             />
-          )}
-        />
-      </div>
-
-      {/* ── Debtor Section ── */}
-      <FormSectionHeader title="Debtor" variant="teal" />
-      <div className="grid grid-cols-2 gap-3 p-4 sm:grid-cols-4">
-        <div>
-          <label className="text-xs font-medium text-slate-600">
-            Debtor Type
-          </label>
-          <select
-            {...register('debtor_type')}
-            className="mt-1 h-8 w-full rounded border border-slate-300 bg-white px-2 text-sm focus:outline-none focus:border-[#0f7d8e]"
-            disabled={!partyTypeOptions.length}
-          >
-            <option value="">
-              {partyTypeOptions.length ? 'Select type...' : 'Loading...'}
-            </option>
-            {partyTypeOptions.map((option: any) => (
-              <option key={option.value} value={option.value}>
-                {option.label}
-              </option>
-            ))}
-          </select>
-        </div>
-        <div className="col-span-3">
-          <Controller
-            name="debtor_id"
-            control={control}
-            render={({ field }) => (
-              <AutocompleteInput
-                label="Name / ID / Reg. No."
-                placeholder="Search debtor..."
-                queryKey={`collateral-debtor-${watch('debtor_type')}`}
-                displayLabel={debtorDisplayLabel}
-                fetchFn={(q) =>
-                  watch('debtor_type') === 'company'
-                    ? companiesApi.searchBranches(q)
-                    : individualsApi.searchIndividuals(q)
-                }
-                error={errors.debtor_id?.message}
-                value={field.value}
-                onBlur={field.onBlur}
-                onChange={(v) => field.onChange(Number(v))}
-              />
-            )}
-          />
-        </div>
-      </div>
-
-      {/* ── Agreement & Asset Details ── */}
-      <FormSectionHeader title="Agreement & Asset Details" variant="dark" />
-      <div className="grid grid-cols-2 gap-3 p-4 sm:grid-cols-4">
-        <Input
-          label="Agreement Number"
-          {...register('agreement_number')}
-          error={errors.agreement_number?.message}
-          required
-        />
-        <div>
-          <label className="text-xs font-medium text-slate-600">
-            Asset Type<span className="text-red-500 ml-0.5">*</span>
-          </label>
-          <select
-            {...register('asset_type')}
-            className="mt-1 h-8 w-full rounded border border-slate-300 bg-white px-2 text-sm focus:outline-none focus:border-[#0f7d8e]"
-            disabled={!assetTypeOptions.length}
-          >
-            <option value="">
-              {assetTypeOptions.length ? 'Click to select...' : 'Loading...'}
-            </option>
-            {assetTypeOptions.map((t: any) => (
-              <option key={t.value} value={t.value}>
-                {t.label}
-              </option>
-            ))}
-          </select>
-          <FieldError message={errors.asset_type?.message} />
-        </div>
-        <Input
-          label="Make"
-          {...register('asset_make')}
-          error={errors.asset_make?.message}
-          required
-        />
-        <Input
-          label="Model"
-          {...register('asset_model')}
-          error={errors.asset_model?.message}
-          required
-        />
-        <Input
-          label="Year"
-          type="number"
-          {...register('asset_year')}
-          error={errors.asset_year?.message}
-          required
-        />
-        <div>
-          <label className="text-xs font-medium text-slate-600">
-            Condition
-          </label>
-          <select
-            {...register('asset_condition')}
-            className="mt-1 h-8 w-full rounded border border-slate-300 bg-white px-2 text-sm focus:outline-none focus:border-[#0f7d8e]"
-            disabled={!assetConditionOptions.length}
-          >
-            <option value="">
-              {assetConditionOptions.length ? 'Select...' : 'Loading...'}
-            </option>
-            {assetConditionOptions.map((c: any) => (
-              <option key={c.value} value={c.value}>
-                {c.label}
-              </option>
-            ))}
-          </select>
-        </div>
-        <Input
-          label="MV Registration No."
-          {...register('asset_registration_no')}
-          disabled={!isVehicle}
-          className={!isVehicle ? 'bg-slate-100' : ''}
-        />
-        <Input
-          label="Chassis Number"
-          {...register('chassis_number')}
-          disabled={!isVehicle}
-          className={!isVehicle ? 'bg-slate-100' : ''}
-        />
-        <Input
-          label="Engine Number"
-          {...register('engine_number')}
-          disabled={!isVehicle}
-          className={!isVehicle ? 'bg-slate-100' : ''}
-        />
-        <Input label="Serial Number" {...register('serial_number')} />
-      </div>
-
-      {/* ── Financial Details ── */}
-      <FormSectionHeader title="Financial Details" variant="teal" />
-      <div className="grid grid-cols-2 gap-3 p-4 sm:grid-cols-4">
-        <div>
-          <label className="text-xs font-medium text-slate-600">
-            Currency<span className="text-red-500 ml-0.5">*</span>
-          </label>
-          <select
-            {...register('currency')}
-            className="mt-1 h-8 w-full rounded border border-slate-300 bg-white px-2 text-sm focus:outline-none focus:border-[#0f7d8e]"
-            disabled={!currencies.length}
-          >
-            <option value="">
-              {currencies.length ? 'Select currency...' : 'Loading...'}
-            </option>
-            {currencies.map((currency) => (
-              <option key={currency.code} value={currency.code}>
-                {currency.code} - {currency.name}
-              </option>
-            ))}
-          </select>
-        </div>
-        <Input
-          label="Total Debt"
-          type="number"
-          step="0.01"
-          {...register('loan_amount')}
-          error={errors.loan_amount?.message}
-          required
-        />
-        <Input
-          label="Instalment Amount"
-          type="number"
-          step="0.01"
-          {...register('instalment_amount')}
-        />
-        <Input
-          label="Instalment Date (dd)"
-          type="number"
-          min="1"
-          max="31"
-          {...register('instalment_date')}
-        />
-        <Input
-          label="Total Paid to Date"
-          type="number"
-          step="0.01"
-          {...register('total_paid_to_date')}
-        />
-        <div>
-          <label className="text-xs font-medium text-slate-600">Balance</label>
-          <div className="mt-1 flex h-8 w-full items-center rounded border border-slate-200 bg-slate-50 px-2 text-sm text-slate-700">
-            {computedBalance.toFixed(2)}
           </div>
         </div>
-        <Controller
-          name="start_date"
-          control={control}
-          render={({ field, fieldState }) => (
-            <DateInput
-              label="Agreement Start Date"
-              value={field.value}
-              onChange={field.onChange}
-              onBlur={field.onBlur}
-              error={fieldState.error?.message}
-              required
-            />
-          )}
-        />
-        <Controller
-          name="end_date"
-          control={control}
-          render={({ field, fieldState }) => (
-            <DateInput
-              label="Agreement End Date"
-              value={field.value}
-              onChange={field.onChange}
-              onBlur={field.onBlur}
-              error={fieldState.error?.message}
-              required
-            />
-          )}
-        />
-      </div>
 
-      {/* ── Footer ── */}
-      <div className="flex items-center justify-between border-t border-slate-200 bg-slate-50 px-4 py-3">
-        <Button type="button" variant="ghost" onClick={onCancel}>
-          Cancel
-        </Button>
-        <Button type="submit" loading={isPending}>
-          {isEdit ? 'Save Changes' : 'Upload'}
-        </Button>
-      </div>
-    </form>
+        {/* ── Agreement & Asset Details ── */}
+        <FormSectionHeader title="Agreement & Asset Details" variant="dark" />
+        <div className="grid grid-cols-2 gap-3 p-4 sm:grid-cols-4">
+          <Input
+            label="Agreement Number"
+            {...register('agreement_number')}
+            error={errors.agreement_number?.message}
+            required
+          />
+          <div>
+            <label className="text-xs font-medium text-slate-600">
+              Asset Type<span className="text-red-500 ml-0.5">*</span>
+            </label>
+            <select
+              {...register('asset_type')}
+              className="mt-1 h-8 w-full rounded border border-slate-300 bg-white px-2 text-sm focus:outline-none focus:border-[#0f7d8e]"
+              disabled={!assetTypeOptions.length}
+            >
+              <option value="">
+                {assetTypeOptions.length ? 'Click to select...' : 'Loading...'}
+              </option>
+              {assetTypeOptions.map((t: any) => (
+                <option key={t.value} value={t.value}>
+                  {t.label}
+                </option>
+              ))}
+            </select>
+            <FieldError message={errors.asset_type?.message} />
+          </div>
+          <Input
+            label="Make"
+            {...register('asset_make')}
+            error={errors.asset_make?.message}
+            required
+          />
+          <Input
+            label="Model"
+            {...register('asset_model')}
+            error={errors.asset_model?.message}
+            required
+          />
+          <Input
+            label="Year"
+            type="number"
+            {...register('asset_year')}
+            error={errors.asset_year?.message}
+            required
+          />
+          <div>
+            <label className="text-xs font-medium text-slate-600">
+              Condition
+            </label>
+            <select
+              {...register('asset_condition')}
+              className="mt-1 h-8 w-full rounded border border-slate-300 bg-white px-2 text-sm focus:outline-none focus:border-[#0f7d8e]"
+              disabled={!assetConditionOptions.length}
+            >
+              <option value="">
+                {assetConditionOptions.length ? 'Select...' : 'Loading...'}
+              </option>
+              {assetConditionOptions.map((c: any) => (
+                <option key={c.value} value={c.value}>
+                  {c.label}
+                </option>
+              ))}
+            </select>
+            <FieldError message={errors.asset_condition?.message} />
+          </div>
+          <Input
+            label="MV Registration No."
+            {...register('asset_registration_no')}
+            disabled={!isVehicle}
+            className={!isVehicle ? 'bg-slate-100' : ''}
+          />
+          <Input
+            label="Chassis Number"
+            {...register('chassis_number')}
+            disabled={!isVehicle}
+            className={!isVehicle ? 'bg-slate-100' : ''}
+          />
+          <Input
+            label="Engine Number"
+            {...register('engine_number')}
+            disabled={!isVehicle}
+            className={!isVehicle ? 'bg-slate-100' : ''}
+          />
+          <Input label="Serial Number" {...register('serial_number')} />
+        </div>
+
+        {/* ── Financial Details ── */}
+        <FormSectionHeader title="Financial Details" variant="teal" />
+        <div className="grid grid-cols-2 gap-3 p-4 sm:grid-cols-4">
+          <div>
+            <label className="text-xs font-medium text-slate-600">
+              Currency<span className="text-red-500 ml-0.5">*</span>
+            </label>
+            <select
+              {...register('currency')}
+              className="mt-1 h-8 w-full rounded border border-slate-300 bg-white px-2 text-sm focus:outline-none focus:border-[#0f7d8e]"
+              disabled={!currencies.length}
+            >
+              <option value="">
+                {currencies.length ? 'Select currency...' : 'Loading...'}
+              </option>
+              {currencies.map((currency) => (
+                <option key={currency.code} value={currency.code}>
+                  {currency.code} - {currency.name}
+                </option>
+              ))}
+            </select>
+            <FieldError message={errors.currency?.message} />
+          </div>
+          <Input
+            label="Total Debt"
+            type="number"
+            step="0.01"
+            {...register('loan_amount')}
+            error={errors.loan_amount?.message}
+            required
+          />
+          <Input
+            label="Instalment Amount"
+            type="number"
+            step="0.01"
+            {...register('instalment_amount')}
+          />
+          <Input
+            label="Instalment Date (dd)"
+            type="number"
+            min="1"
+            max="31"
+            {...register('instalment_date')}
+            error={errors.instalment_date?.message}
+          />
+          <Input
+            label="Total Paid to Date"
+            type="number"
+            step="0.01"
+            {...register('total_paid_to_date')}
+          />
+          <div>
+            <label className="text-xs font-medium text-slate-600">
+              Balance
+            </label>
+            <div className="mt-1 flex h-8 w-full items-center rounded border border-slate-200 bg-slate-50 px-2 text-sm text-slate-700">
+              {computedBalance.toFixed(2)}
+            </div>
+          </div>
+          <Controller
+            name="start_date"
+            control={control}
+            render={({ field, fieldState }) => (
+              <DateInput
+                label="Agreement Start Date"
+                value={field.value}
+                onChange={field.onChange}
+                onBlur={field.onBlur}
+                error={fieldState.error?.message}
+                required
+              />
+            )}
+          />
+          <Controller
+            name="end_date"
+            control={control}
+            render={({ field, fieldState }) => (
+              <DateInput
+                label="Agreement End Date"
+                value={field.value}
+                onChange={field.onChange}
+                onBlur={field.onBlur}
+                error={fieldState.error?.message}
+                required
+              />
+            )}
+          />
+        </div>
+
+        {/* ── Footer ── */}
+        <div className="flex items-center justify-between border-t border-slate-200 bg-slate-50 px-4 py-3">
+          <Button type="button" variant="ghost" onClick={onCancel}>
+            {onSuccessAndAddAnother ? 'Done' : 'Cancel'}
+          </Button>
+          <div className="flex gap-2">
+            {onSuccessAndAddAnother && !isEdit && (
+              <Button
+                type="submit"
+                variant="secondary"
+                loading={isPending && addAnother}
+                disabled={isPending && !addAnother}
+                onClick={() => setAddAnother(true)}
+              >
+                Save & Add Another
+              </Button>
+            )}
+            <Button
+              type="submit"
+              loading={isPending && !addAnother}
+              disabled={isPending && addAnother}
+              onClick={() => setAddAnother(false)}
+            >
+              {isEdit
+                ? 'Save Changes'
+                : onSuccessAndAddAnother
+                  ? 'Save'
+                  : 'Upload'}
+            </Button>
+          </div>
+        </div>
+      </form>
+
+      <Modal
+        open={addClientOpen}
+        onClose={() => setAddClientOpen(false)}
+        title="Add Client"
+        size="md"
+      >
+        <ClientCreateForm
+          onCancel={() => setAddClientOpen(false)}
+          initialEntityType={financierClientType}
+          onSuccess={({ id, name }) => {
+            setValue('financier_id', id, { shouldValidate: true });
+            setFinancierLabel(name);
+            setAddClientOpen(false);
+          }}
+        />
+      </Modal>
+
+      <Modal
+        open={addIndividualOpen}
+        onClose={() => setAddIndividualOpen(false)}
+        title="Add Individual"
+        size="lg"
+      >
+        <IndividualCreateForm
+          onCancel={() => setAddIndividualOpen(false)}
+          onSuccess={({ id, name }) => {
+            setValue('debtor_type', 'individual');
+            setValue('debtor_id', id, { shouldValidate: true });
+            setDebtorLabel(name);
+            setAddIndividualOpen(false);
+          }}
+        />
+      </Modal>
+
+      <Modal
+        open={addCompanyOpen}
+        onClose={() => setAddCompanyOpen(false)}
+        title="Add Company"
+        size="lg"
+        disableBackdropClose
+      >
+        <CompanyCreateForm
+          onCancel={() => setAddCompanyOpen(false)}
+          onSuccess={({ id, name }) => {
+            setValue('debtor_type', 'company');
+            setValue('debtor_id', id, { shouldValidate: true });
+            setDebtorLabel(name);
+            setAddCompanyOpen(false);
+          }}
+        />
+      </Modal>
+    </>
   );
 }

--- a/frontend/src/components/collateral/CollateralViewModal.tsx
+++ b/frontend/src/components/collateral/CollateralViewModal.tsx
@@ -67,9 +67,10 @@ export function CollateralViewModal({
             isEdit
             recordId={record.id}
             financierDisplayLabel={detail.financier_name}
+            dataSourceDisplayLabel={detail.data_source_display}
+            dataSourcePositionLabel={detail.data_source_position}
             debtorDisplayLabel={detail.debtor_name}
             initial={{
-              financier_type: detail.financier_type,
               financier_id: detail.financier_id,
               data_date: detail.data_date,
               debtor_type: detail.debtor_type,
@@ -106,6 +107,14 @@ export function CollateralViewModal({
           <div className="grid grid-cols-2 gap-x-8 gap-y-3 text-sm sm:grid-cols-3">
             {[
               ['Financier', detail?.financier_name ?? record.financier_name],
+              [
+                'Data Source Name',
+                detail?.data_source_display ?? record.data_source_display,
+              ],
+              [
+                'Position',
+                detail?.data_source_position ?? record.data_source_position,
+              ],
               ['Debtor', detail?.debtor_name ?? record.debtor_name],
               ['Agreement No.', record.agreement_number],
               [

--- a/frontend/src/components/collateral/CollateralViewModal.tsx
+++ b/frontend/src/components/collateral/CollateralViewModal.tsx
@@ -2,27 +2,25 @@ import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { Modal } from '@/components/shared/Modal';
+import { ConfirmDialog } from '@/components/shared/ConfirmDialog';
 import { CollateralForm } from './CollateralForm';
 import type { CollateralRecord } from '@/types';
 import { formatCurrency, formatDate } from '@/lib/utils';
 import { assetTypeLabel } from '@/lib/assetTypes';
 import { Button } from '@/components/ui/button';
-import { Edit, CheckCircle } from 'lucide-react';
-import { DeleteRecordButton } from '@/components/shared/DeleteRecordButton';
+import { Edit } from 'lucide-react';
 import { collateralApi } from '@/api/collateralApi';
 
 interface CollateralViewModalProps {
   record: CollateralRecord;
   onClose: () => void;
   onSaved: () => void;
-  onDeleted: () => void;
 }
 
 export function CollateralViewModal({
   record,
   onClose,
   onSaved,
-  onDeleted,
 }: CollateralViewModalProps) {
   const [editMode, setEditMode] = useState(false);
   const [confirmingDischarge, setConfirmingDischarge] = useState(false);
@@ -33,8 +31,6 @@ export function CollateralViewModal({
     queryFn: () => collateralApi.getRecord(record.id),
     staleTime: 5 * 60 * 1000,
   });
-
-  const currentStatus = detail?.status ?? record.status;
 
   const { mutate: discharge, isPending: isDischarging } = useMutation({
     mutationFn: () => collateralApi.dischargeRecord(record.id),
@@ -55,159 +51,122 @@ export function CollateralViewModal({
   });
 
   return (
-    <Modal
-      open
-      onClose={onClose}
-      title={`Collateral — ${record.agreement_number}`}
-      size="xl"
-    >
-      {editMode ? (
-        detail ? (
-          <CollateralForm
-            isEdit
-            recordId={record.id}
-            financierDisplayLabel={detail.financier_name}
-            dataSourceDisplayLabel={detail.data_source_display}
-            dataSourcePositionLabel={detail.data_source_position}
-            debtorDisplayLabel={detail.debtor_name}
-            initial={{
-              financier_id: detail.financier_id,
-              data_date: detail.data_date,
-              debtor_type: detail.debtor_type,
-              debtor_id: detail.debtor_id,
-              agreement_number: detail.agreement_number,
-              asset_type: detail.asset_type,
-              asset_make: detail.asset_make,
-              asset_model: detail.asset_model,
-              asset_year: detail.asset_year,
-              asset_condition: detail.asset_condition,
-              asset_registration_no: detail.asset_registration_no,
-              chassis_number: detail.chassis_number,
-              engine_number: detail.engine_number,
-              serial_number: detail.serial_number,
-              currency: detail.currency,
-              loan_amount: detail.loan_amount,
-              instalment_amount: detail.instalment_amount,
-              instalment_date: detail.instalment_date,
-              total_paid_to_date: detail.total_paid_to_date,
-              start_date: detail.start_date,
-              end_date: detail.end_date,
-            }}
-            onSuccess={onSaved}
-            onCancel={() => setEditMode(false)}
-          />
-        ) : (
-          <div className="flex items-center justify-center p-10 text-sm text-slate-400">
-            Loading…
-          </div>
-        )
-      ) : (
-        <div className="p-5 space-y-4 bg-white">
-          {/* Detail grid */}
-          <div className="grid grid-cols-2 gap-x-8 gap-y-3 text-sm sm:grid-cols-3">
-            {[
-              ['Financier', detail?.financier_name ?? record.financier_name],
-              [
-                'Data Source Name',
-                detail?.data_source_display ?? record.data_source_display,
-              ],
-              [
-                'Position',
-                detail?.data_source_position ?? record.data_source_position,
-              ],
-              ['Debtor', detail?.debtor_name ?? record.debtor_name],
-              ['Agreement No.', record.agreement_number],
-              [
-                'Asset',
-                `${detail?.asset_make ?? ''} ${detail?.asset_model ?? ''}`.trim() ||
-                  record.asset_description,
-              ],
-              [
-                'Asset Type',
-                assetTypeLabel(detail?.asset_type ?? record.asset_type),
-              ],
-              ['Year', detail?.asset_year ?? record.asset_year],
-              ['Condition', detail?.asset_condition ?? record.asset_condition],
-              [
-                'Reg/Serial',
-                detail?.serial_number ||
-                  detail?.asset_registration_no ||
-                  record.serial_number ||
-                  record.asset_registration_no,
-              ],
-              ['Currency', detail?.currency ?? record.currency],
-              [
-                'Loan Amount',
-                formatCurrency(detail?.loan_amount ?? record.loan_amount),
-              ],
-              [
-                'Instalment',
-                formatCurrency(
-                  detail?.instalment_amount ?? record.instalment_amount,
-                ),
-              ],
-              ['Balance', formatCurrency(detail?.balance ?? record.balance)],
-              [
-                'Start Date',
-                formatDate(detail?.start_date ?? record.start_date),
-              ],
-              ['End Date', formatDate(detail?.end_date ?? record.end_date)],
-              ['Status', detail?.status ?? record.status],
-            ].map(([k, v]) => (
-              <div key={String(k)}>
-                <dt className="text-xs font-medium uppercase text-slate-400">
-                  {k}
-                </dt>
-                <dd className="mt-0.5 font-medium text-slate-800">
-                  {String(v ?? '—')}
-                </dd>
-              </div>
-            ))}
-          </div>
-          <div className="flex flex-wrap items-center justify-between gap-2 pt-2 border-t border-slate-100">
-            <DeleteRecordButton
-              onDelete={() => collateralApi.deleteRecord(record.id)}
-              onDeleted={onDeleted}
+    <>
+      <Modal
+        open
+        onClose={onClose}
+        title={`Collateral — ${record.agreement_number}`}
+        size="xl"
+      >
+        {editMode ? (
+          detail ? (
+            <CollateralForm
+              isEdit
+              recordId={record.id}
+              financierDisplayLabel={detail.financier_name}
+              dataSourceDisplayLabel={detail.data_source_display}
+              dataSourcePositionLabel={detail.data_source_position}
+              debtorDisplayLabel={detail.debtor_name}
+              initial={{
+                financier_id: detail.financier_id,
+                data_date: detail.data_date,
+                debtor_type: detail.debtor_type,
+                debtor_id: detail.debtor_id,
+                agreement_number: detail.agreement_number,
+                asset_type: detail.asset_type,
+                asset_make: detail.asset_make,
+                asset_model: detail.asset_model,
+                asset_year: detail.asset_year,
+                asset_condition: detail.asset_condition,
+                asset_registration_no: detail.asset_registration_no,
+                chassis_number: detail.chassis_number,
+                engine_number: detail.engine_number,
+                serial_number: detail.serial_number,
+                currency: detail.currency,
+                loan_amount: detail.loan_amount,
+                instalment_amount: detail.instalment_amount,
+                instalment_date: detail.instalment_date,
+                total_paid_to_date: detail.total_paid_to_date,
+                start_date: detail.start_date,
+                end_date: detail.end_date,
+              }}
+              onSuccess={onSaved}
+              onCancel={() => setEditMode(false)}
+              onDischarge={() => setConfirmingDischarge(true)}
+              dischargePending={isDischarging}
             />
-            <div className="flex gap-2 items-center">
-              {currentStatus !== 'discharged' &&
-                (confirmingDischarge ? (
-                  <>
-                    <span className="text-xs text-amber-700">
-                      Confirm discharge?
-                    </span>
-                    <Button
-                      type="button"
-                      size="sm"
-                      variant="primary"
-                      loading={isDischarging}
-                      onClick={() => discharge()}
-                    >
-                      Yes, Discharge
-                    </Button>
-                    <Button
-                      type="button"
-                      size="sm"
-                      variant="ghost"
-                      onClick={() => setConfirmingDischarge(false)}
-                    >
-                      Cancel
-                    </Button>
-                  </>
-                ) : (
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="secondary"
-                    leftIcon={<CheckCircle className="h-3.5 w-3.5" />}
-                    onClick={() => setConfirmingDischarge(true)}
-                  >
-                    Discharge
-                  </Button>
-                ))}
-              <Button variant="ghost" onClick={onClose}>
-                Close
-              </Button>
+          ) : (
+            <div className="flex items-center justify-center p-10 text-sm text-slate-400">
+              Loading…
+            </div>
+          )
+        ) : (
+          <div className="p-5 space-y-4 bg-white">
+            {/* Detail grid */}
+            <div className="grid grid-cols-2 gap-x-8 gap-y-3 text-sm sm:grid-cols-3">
+              {[
+                ['Financier', detail?.financier_name ?? record.financier_name],
+                [
+                  'Data Source Name',
+                  detail?.data_source_display ?? record.data_source_display,
+                ],
+                [
+                  'Position',
+                  detail?.data_source_position ?? record.data_source_position,
+                ],
+                ['Debtor', detail?.debtor_name ?? record.debtor_name],
+                ['Agreement No.', record.agreement_number],
+                [
+                  'Asset',
+                  `${detail?.asset_make ?? ''} ${detail?.asset_model ?? ''}`.trim() ||
+                    record.asset_description,
+                ],
+                [
+                  'Asset Type',
+                  assetTypeLabel(detail?.asset_type ?? record.asset_type),
+                ],
+                ['Year', detail?.asset_year ?? record.asset_year],
+                [
+                  'Condition',
+                  detail?.asset_condition ?? record.asset_condition,
+                ],
+                [
+                  'Reg/Serial',
+                  detail?.serial_number ||
+                    detail?.asset_registration_no ||
+                    record.serial_number ||
+                    record.asset_registration_no,
+                ],
+                ['Currency', detail?.currency ?? record.currency],
+                [
+                  'Loan Amount',
+                  formatCurrency(detail?.loan_amount ?? record.loan_amount),
+                ],
+                [
+                  'Instalment',
+                  formatCurrency(
+                    detail?.instalment_amount ?? record.instalment_amount,
+                  ),
+                ],
+                ['Balance', formatCurrency(detail?.balance ?? record.balance)],
+                [
+                  'Start Date',
+                  formatDate(detail?.start_date ?? record.start_date),
+                ],
+                ['End Date', formatDate(detail?.end_date ?? record.end_date)],
+                ['Status', detail?.status ?? record.status],
+              ].map(([k, v]) => (
+                <div key={String(k)}>
+                  <dt className="text-xs font-medium uppercase text-slate-400">
+                    {k}
+                  </dt>
+                  <dd className="mt-0.5 font-medium text-slate-800">
+                    {String(v ?? '—')}
+                  </dd>
+                </div>
+              ))}
+            </div>
+            <div className="flex items-center justify-end gap-2 pt-2 border-t border-slate-100">
               <Button
                 leftIcon={<Edit className="h-3.5 w-3.5" />}
                 onClick={() => setEditMode(true)}
@@ -216,8 +175,19 @@ export function CollateralViewModal({
               </Button>
             </div>
           </div>
-        </div>
-      )}
-    </Modal>
+        )}
+      </Modal>
+
+      <ConfirmDialog
+        open={confirmingDischarge}
+        title="Confirm Discharge"
+        message="Are you sure you want to mark this collateral as discharged?"
+        confirmLabel="Yes, Discharge"
+        variant="danger"
+        loading={isDischarging}
+        onConfirm={() => discharge()}
+        onCancel={() => setConfirmingDischarge(false)}
+      />
+    </>
   );
 }

--- a/frontend/src/components/hire-purchase/HirePurchaseForm.tsx
+++ b/frontend/src/components/hire-purchase/HirePurchaseForm.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useForm, useFormState, Controller } from 'react-hook-form';
 import { zodResolver } from '@/lib/zodResolver';
 import { applyApiValidationErrors } from '@/lib/formErrors';
@@ -21,17 +21,17 @@ import { FormSectionHeader } from '@/components/shared/FormSectionHeader';
 import { FieldError } from '@/components/shared/FieldError';
 import { commonApi } from '@/api/commonApi';
 import { queryOptions } from '@/api/queryOptions';
+import { useAuthStore } from '@/store';
+import { isStaffUser } from '@/lib/registryNav';
+import { cn } from '@/lib/utils';
+import { authApi } from '@/api/authApi';
 
-const schema = z.object({
-  financier_id: z
-    .number({ error: 'Financier is required' })
-    .min(1, 'Financier is required'),
+const hpCoreSchema = z.object({
   data_date: z.string().min(1, 'Required'),
   purchaser_type: z.string().min(1, 'Purchaser Type is required'),
   purchaser_id: z
     .number({ error: 'Purchaser is required' })
     .min(1, 'Purchaser is required'),
-  purchaser_search: z.string().optional(),
   agreement_number: z.string().min(1, 'Required'),
   asset_type: z.string().min(1, 'Select asset type'),
   asset_make: z.string().min(1, 'Required'),
@@ -51,12 +51,37 @@ const schema = z.object({
   end_date: z.string().min(1),
 });
 
-type FormValues = z.infer<typeof schema>;
+const staffHpSchema = hpCoreSchema.extend({
+  financier_id: z
+    .number({ error: 'Financier is required' })
+    .min(1, 'Financier is required'),
+});
+
+function buildHpSchema(isClientUser: boolean) {
+  return isClientUser ? hpCoreSchema : staffHpSchema;
+}
+
+type CoreFormValues = z.infer<typeof hpCoreSchema>;
+type StaffFormValues = z.infer<typeof staffHpSchema>;
+type FormValues = CoreFormValues & { financier_id?: number };
+
+function ReadOnlyField({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="space-y-1">
+      <label className="text-xs font-medium text-slate-700">{label}</label>
+      <div className="flex h-8 w-full items-center rounded-sm border border-slate-200 bg-slate-50 px-2.5 text-sm text-slate-800">
+        {value || '—'}
+      </div>
+    </div>
+  );
+}
 
 interface HirePurchaseFormProps {
   initial?: Partial<FormValues>;
   financierDisplayLabel?: string;
   purchaserDisplayLabel?: string;
+  dataSourceDisplayLabel?: string;
+  dataSourcePositionLabel?: string;
   onSuccess: () => void;
   onSaveAndAdd?: () => void;
   onCancel: () => void;
@@ -68,17 +93,53 @@ export function HirePurchaseForm({
   initial,
   financierDisplayLabel,
   purchaserDisplayLabel,
+  dataSourceDisplayLabel,
+  dataSourcePositionLabel,
   onSuccess,
   onSaveAndAdd,
   onCancel,
   isEdit,
   recordId,
 }: HirePurchaseFormProps) {
+  const user = useAuthStore((s) => s.user);
+  const setUser = useAuthStore((s) => s.setUser);
+  const isStaff = isStaffUser(user);
+  const isClientUser = !isStaff && !!user;
+  const clientFinancierId = user?.client_id;
+
+  const formSchema = useMemo(
+    () => buildHpSchema(isClientUser && !isEdit),
+    [isClientUser, isEdit],
+  );
+
   const [addIndividualOpen, setAddIndividualOpen] = useState(false);
   const [addCompanyOpen, setAddCompanyOpen] = useState(false);
+  const [financierLabel, setFinancierLabel] = useState(
+    financierDisplayLabel ?? '',
+  );
+  const [financierClientType, setFinancierClientType] = useState<
+    'individual' | 'company'
+  >('company');
+  const isFirstFinancierClientTypeRender = useRef(true);
+  const [purchaserLabel, setPurchaserLabel] = useState(
+    purchaserDisplayLabel ?? '',
+  );
+  const isFirstPurchaserTypeRender = useRef(true);
+  const [dataSourceUserId, setDataSourceUserId] = useState<number | undefined>();
+  const [staffDataSourceName, setStaffDataSourceName] = useState('');
+  const [staffDataSourcePosition, setStaffDataSourcePosition] = useState('');
+  const [staffDataSourceSearchLabel, setStaffDataSourceSearchLabel] = useState('');
+
+  const clearDataSource = () => {
+    setDataSourceUserId(undefined);
+    setStaffDataSourceName('');
+    setStaffDataSourcePosition('');
+    setStaffDataSourceSearchLabel('');
+  };
+
   const { register, control, handleSubmit, watch, reset, setValue, setError } =
     useForm<FormValues>({
-      resolver: zodResolver(schema),
+      resolver: zodResolver(formSchema),
       mode: 'onSubmit',
       reValidateMode: 'onChange',
       shouldFocusError: true,
@@ -90,6 +151,7 @@ export function HirePurchaseForm({
         asset_condition: 'new',
         total_paid_to_date: 0,
         balance: 0,
+        ...(isClientUser && !isEdit ? {} : {}),
         ...initial,
       },
     });
@@ -110,6 +172,33 @@ export function HirePurchaseForm({
   const assetTypeOptions = choices.BaseAssetType ?? [];
   const assetConditionOptions = choices.AssetCondition ?? [];
   const currentPurchaserType = watch('purchaser_type');
+  const selectedFinancierId = watch('financier_id');
+
+  const { data: clientUsers = [] } = useQuery({
+    queryKey: ['hp-client-users', selectedFinancierId],
+    queryFn: () => clientsApi.listClientUsers(Number(selectedFinancierId)),
+    enabled:
+      !isEdit &&
+      isStaff &&
+      !!selectedFinancierId &&
+      Number(selectedFinancierId) > 0,
+  });
+
+  const { data: clientDetail } = useQuery({
+    queryKey: ['hp-client-detail', selectedFinancierId],
+    queryFn: () => clientsApi.getClient(Number(selectedFinancierId)),
+    enabled:
+      !isEdit &&
+      isStaff &&
+      financierClientType === 'individual' &&
+      !!selectedFinancierId &&
+      Number(selectedFinancierId) > 0,
+  });
+
+  const purchaserTypeLabel =
+    partyTypeOptions.find(
+      (option: { value: string }) => option.value === currentPurchaserType,
+    )?.label ?? currentPurchaserType;
 
   useEffect(() => {
     if (!watch('currency') && currencies.length > 0) {
@@ -128,13 +217,92 @@ export function HirePurchaseForm({
   useEffect(() => {
     if (!currentPurchaserType && partyTypeOptions.length > 0) {
       const defaultPurchaser =
-        partyTypeOptions.find((p: any) => p.value === 'individual') ||
+        partyTypeOptions.find((p: { value: string }) => p.value === 'individual') ||
         partyTypeOptions[0];
       setValue('purchaser_type', defaultPurchaser.value, {
         shouldValidate: true,
       });
     }
   }, [partyTypeOptions, setValue, currentPurchaserType]);
+
+  useEffect(() => {
+    if (isStaff || user?.client_id) return;
+    void authApi.me().then(setUser).catch(() => {});
+  }, [isStaff, user?.client_id, setUser]);
+
+  useEffect(() => {
+    if (!isClientUser || isEdit) return;
+    if (financierDisplayLabel) {
+      setFinancierLabel(financierDisplayLabel);
+    } else {
+      setFinancierLabel(user?.client_name ?? '');
+    }
+  }, [isClientUser, isEdit, user?.client_name, financierDisplayLabel]);
+
+  useEffect(() => {
+    if (isClientUser || isEdit) return;
+    if (isFirstFinancierClientTypeRender.current) {
+      isFirstFinancierClientTypeRender.current = false;
+      return;
+    }
+    setValue('financier_id', 0 as unknown as number);
+    setFinancierLabel('');
+    clearDataSource();
+  }, [financierClientType, isClientUser, isEdit, setValue]);
+
+  useEffect(() => {
+    if (isEdit || isClientUser) return;
+    clearDataSource();
+  }, [selectedFinancierId, isEdit, isClientUser]);
+
+  useEffect(() => {
+    if (isEdit || !isStaff || financierClientType !== 'individual' || !clientDetail) {
+      return;
+    }
+    const details = clientDetail.client_details;
+    const individualName =
+      (details?.full_name ??
+        `${details?.first_name ?? ''} ${details?.last_name ?? ''}`.trim()) ||
+      clientDetail.name;
+    setStaffDataSourceName(individualName);
+    setStaffDataSourceSearchLabel(individualName);
+    setStaffDataSourcePosition('');
+  }, [clientDetail, financierClientType, isEdit, isStaff]);
+
+  useEffect(() => {
+    if (isEdit || !isStaff || financierClientType !== 'individual') return;
+    if (clientUsers.length === 1) {
+      const linkedUser = clientUsers[0];
+      setDataSourceUserId(linkedUser.id);
+      if (linkedUser.position) {
+        setStaffDataSourcePosition(linkedUser.position);
+      }
+    }
+  }, [clientUsers, financierClientType, isEdit, isStaff]);
+
+  useEffect(() => {
+    if (isEdit) return;
+    if (isFirstPurchaserTypeRender.current) {
+      isFirstPurchaserTypeRender.current = false;
+      return;
+    }
+    setValue('purchaser_id', 0 as unknown as number);
+    setPurchaserLabel('');
+    setAddIndividualOpen(false);
+    setAddCompanyOpen(false);
+  }, [currentPurchaserType, isEdit, setValue]);
+
+  useEffect(() => {
+    if (purchaserDisplayLabel) {
+      setPurchaserLabel(purchaserDisplayLabel);
+    }
+  }, [purchaserDisplayLabel]);
+
+  useEffect(() => {
+    if (financierDisplayLabel) {
+      setFinancierLabel(financierDisplayLabel);
+    }
+  }, [financierDisplayLabel]);
 
   const watchAssetType = watch('asset_type');
   const isVehicle = watchAssetType === 'vehicles';
@@ -161,143 +329,369 @@ export function HirePurchaseForm({
     toast.error('Please fix the highlighted fields');
   };
 
+  const buildSubmitPayload = (data: FormValues) => {
+    const payload =
+      isClientUser && !isEdit
+        ? ({ ...data, financier_id: clientFinancierId } as StaffFormValues)
+        : (data as StaffFormValues);
+
+    if (isStaff && !isEdit && dataSourceUserId) {
+      return { ...payload, data_source_user_id: dataSourceUserId };
+    }
+    return payload;
+  };
+
+  const validateStaffDataSource = () => {
+    if (!isStaff || isEdit || !selectedFinancierId || Number(selectedFinancierId) <= 0) {
+      return true;
+    }
+    if (financierClientType === 'company' && !dataSourceUserId) {
+      toast.error('Please select a data source user for this company financier.');
+      return false;
+    }
+    return true;
+  };
+
+  const onFormSubmit = handleSubmit((data) => {
+    if (isClientUser && !isEdit) {
+      if (!clientFinancierId) {
+        toast.error(
+          'Unable to load your financier profile. Please refresh and try again.',
+        );
+        return;
+      }
+    }
+    if (!validateStaffDataSource()) return;
+    submit(buildSubmitPayload(data) as any);
+  }, onInvalid);
+
   const handleSaveAndAdd = handleSubmit((data) => {
-    submit(data, {
+    if (isClientUser && !isEdit && !clientFinancierId) {
+      toast.error(
+        'Unable to load your financier profile. Please refresh and try again.',
+      );
+      return;
+    }
+    if (!validateStaffDataSource()) return;
+
+    submit(buildSubmitPayload(data) as any, {
       onSuccess: () => {
         reset();
+        clearDataSource();
         onSaveAndAdd?.();
       },
     });
-  });
+  }, onInvalid);
+
+  const editDataSourceName = dataSourceDisplayLabel ?? '—';
+  const editDataSourcePosition = dataSourcePositionLabel ?? '—';
 
   return (
     <>
-      <form
-        onSubmit={handleSubmit((d) => submit(d), onInvalid)}
-        className="bg-white"
-        noValidate
-      >
-        <div className="flex gap-2 px-4 pt-4 pb-1">
-          <Button
-            type="button"
-            size="sm"
-            variant="primary"
-            leftIcon={<UserPlus className="h-3 w-3" />}
-            onClick={() => setAddIndividualOpen(true)}
-          >
-            + Add Individual
-          </Button>
-          <Button
-            type="button"
-            size="sm"
-            variant="secondary"
-            leftIcon={<Building className="h-3 w-3" />}
-            onClick={() => setAddCompanyOpen(true)}
-          >
-            + Add Company
-          </Button>
-        </div>
+      <form onSubmit={onFormSubmit} className="bg-white" noValidate>
+        {!isEdit && (
+          <div className="flex gap-2 px-4 pt-4 pb-1">
+            <Button
+              type="button"
+              size="sm"
+              variant="primary"
+              leftIcon={<UserPlus className="h-3 w-3" />}
+              onClick={() => setAddIndividualOpen(true)}
+            >
+              + Add Individual
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="secondary"
+              leftIcon={<Building className="h-3 w-3" />}
+              onClick={() => setAddCompanyOpen(true)}
+            >
+              + Add Company
+            </Button>
+          </div>
+        )}
 
         {/* ── Financier Section ── */}
         <FormSectionHeader title="Financier" variant="red" />
-        <div className="grid grid-cols-2 gap-3 p-4 sm:grid-cols-3">
-          <div className="col-span-2">
-            <Controller
-              name="financier_id"
-              control={control}
-              render={({ field }) => (
-                <AutocompleteInput
+        {isEdit ? (
+          <>
+            <div className="grid grid-cols-2 gap-3 p-4 pb-2 sm:grid-cols-4">
+              <div className="col-span-2">
+                <ReadOnlyField
                   label="Financier Name"
-                  placeholder="Search financier..."
-                  queryKey="hp-financier"
-                  displayLabel={financierDisplayLabel}
-                  fetchFn={clientsApi.searchClients}
-                  error={errors.financier_id?.message}
-                  value={field.value}
-                  onBlur={field.onBlur}
-                  onChange={(v) => field.onChange(Number(v))}
+                  value={financierLabel || financierDisplayLabel || ''}
                 />
-              )}
-            />
-          </div>
-          <Controller
-            name="data_date"
-            control={control}
-            render={({ field, fieldState }) => (
-              <DateInput
-                label="Data Date"
-                value={field.value}
-                onChange={field.onChange}
-                onBlur={field.onBlur}
-                error={fieldState.error?.message}
-                required
-              />
-            )}
-          />
-        </div>
-
-        {/* ── Lessee / Purchaser Section ── */}
-        <FormSectionHeader title="Lessee" variant="teal" />
-        <div className="p-4 space-y-3">
-          <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
-            <div>
-              <label className="text-xs font-medium text-slate-600">
-                Purchaser Type
-              </label>
-              <select
-                {...register('purchaser_type')}
-                className="mt-1 h-8 w-full rounded border border-slate-300 bg-white px-2 text-sm focus:outline-none focus:border-[#0f7d8e]"
-                disabled={!partyTypeOptions.length}
-              >
-                <option value="">
-                  {partyTypeOptions.length
-                    ? 'Select type...'
-                    : 'Loading types...'}
-                </option>
-                {partyTypeOptions.map((option: any) => (
-                  <option key={option.value} value={option.value}>
-                    {option.label}
-                  </option>
-                ))}
-              </select>
-            </div>
-          </div>
-
-          {/* Search Purchaser */}
-          <div className="rounded border border-slate-200 bg-slate-50 p-3">
-            <p className="mb-2 text-xs font-semibold text-slate-600 uppercase">
-              Search:{' '}
-              {watch('purchaser_type') === 'individual'
-                ? 'Individual'
-                : 'Company'}
-            </p>
-            <div className="flex gap-2">
+              </div>
               <Controller
-                name="purchaser_id"
+                name="data_date"
                 control={control}
-                render={({ field }) => (
-                  <AutocompleteInput
-                    placeholder={
-                      watch('purchaser_type') === 'individual'
-                        ? 'Search by Name / National ID'
-                        : 'Search by Name / Reg Number'
-                    }
-                    queryKey={`hp-purchaser-${watch('purchaser_type')}`}
-                    displayLabel={purchaserDisplayLabel}
-                    fetchFn={(q) =>
-                      watch('purchaser_type') === 'company'
-                        ? companiesApi.searchBranches(q)
-                        : individualsApi.searchIndividuals(q)
-                    }
+                render={({ field, fieldState }) => (
+                  <DateInput
+                    label="Data Date"
                     value={field.value}
+                    onChange={field.onChange}
                     onBlur={field.onBlur}
-                    error={errors.purchaser_id?.message}
-                    onChange={(v) => field.onChange(Number(v))}
+                    error={fieldState.error?.message}
+                    required
                   />
                 )}
               />
             </div>
-          </div>
+            <div className="grid grid-cols-2 gap-3 px-4 pb-4 sm:grid-cols-4">
+              <div className="col-span-2">
+                <ReadOnlyField
+                  label="Data Source Name"
+                  value={editDataSourceName}
+                />
+              </div>
+              <div className="col-span-2">
+                <ReadOnlyField label="Position" value={editDataSourcePosition} />
+              </div>
+            </div>
+          </>
+        ) : isClientUser ? (
+          <>
+            <div className="grid grid-cols-2 gap-3 p-4 pb-2 sm:grid-cols-4">
+              <div className="col-span-2 space-y-1">
+                <label className="text-xs font-medium text-slate-700">
+                  Financier Name
+                </label>
+                <div
+                  className={cn(
+                    'flex h-8 w-full items-center rounded-sm border bg-slate-50 px-2.5 text-sm text-slate-800',
+                    !clientFinancierId ? 'border-red-500' : 'border-slate-200',
+                  )}
+                >
+                  {financierLabel || user?.client_name || '—'}
+                </div>
+                {!clientFinancierId && (
+                  <FieldError message="Financier profile not loaded. Please refresh the page." />
+                )}
+              </div>
+              <Controller
+                name="data_date"
+                control={control}
+                render={({ field, fieldState }) => (
+                  <DateInput
+                    label="Data Date"
+                    value={field.value}
+                    onChange={field.onChange}
+                    onBlur={field.onBlur}
+                    error={fieldState.error?.message}
+                    required
+                  />
+                )}
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-3 px-4 pb-4 sm:grid-cols-4">
+              <div className="col-span-2">
+                <ReadOnlyField
+                  label="Data Source Name"
+                  value={user?.name ?? ''}
+                />
+              </div>
+              <div className="col-span-2">
+                <ReadOnlyField label="Position" value={user?.position ?? ''} />
+              </div>
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="grid grid-cols-2 gap-3 p-4 pb-2 sm:grid-cols-4">
+              <div className="space-y-1">
+                <label className="text-xs font-medium text-slate-700">
+                  Financier Type
+                </label>
+                <select
+                  value={financierClientType}
+                  onChange={(e) =>
+                    setFinancierClientType(
+                      e.target.value as 'individual' | 'company',
+                    )
+                  }
+                  className="h-8 w-full rounded-sm border border-slate-500 bg-white px-2.5 text-sm text-slate-900 focus:border-black focus:outline-none focus:ring-0"
+                  disabled={!partyTypeOptions.length}
+                >
+                  {partyTypeOptions.length === 0 ? (
+                    <option value="company">Loading...</option>
+                  ) : (
+                    partyTypeOptions.map((option: { value: string; label: string }) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))
+                  )}
+                </select>
+              </div>
+              <div className="col-span-2">
+                <Controller
+                  name="financier_id"
+                  control={control}
+                  render={({ field }) => (
+                    <AutocompleteInput
+                      label="Financier Name"
+                      placeholder="Search financier..."
+                      queryKey={`hp-financier-${financierClientType}`}
+                      displayLabel={financierLabel}
+                      fetchFn={(q) =>
+                        clientsApi.searchClients(q, {
+                          entityType: financierClientType,
+                        })
+                      }
+                      error={errors.financier_id?.message}
+                      value={field.value}
+                      onBlur={field.onBlur}
+                      onChange={(v) => field.onChange(Number(v))}
+                    />
+                  )}
+                />
+              </div>
+              <Controller
+                name="data_date"
+                control={control}
+                render={({ field, fieldState }) => (
+                  <DateInput
+                    label="Data Date"
+                    value={field.value}
+                    onChange={field.onChange}
+                    onBlur={field.onBlur}
+                    error={fieldState.error?.message}
+                    required
+                  />
+                )}
+              />
+            </div>
+            {selectedFinancierId && Number(selectedFinancierId) > 0 ? (
+              <div className="grid grid-cols-2 gap-3 px-4 pb-4 sm:grid-cols-4">
+                <div className="col-span-2">
+                  {financierClientType === 'company' ? (
+                    <AutocompleteInput
+                      label="Data Source Name"
+                      placeholder="Search user under client..."
+                      queryKey={`hp-data-source-${selectedFinancierId}`}
+                      displayLabel={staffDataSourceSearchLabel}
+                      minChars={1}
+                      fetchFn={async (q) => {
+                        const term = q.trim().toLowerCase();
+                        if (!term) return [];
+                        return clientUsers
+                          .filter(
+                            (u) =>
+                              u.name.toLowerCase().includes(term) ||
+                              (u.position?.toLowerCase().includes(term) ?? false),
+                          )
+                          .map((u) => ({
+                            id: u.id,
+                            name: u.name,
+                            subtitle: u.position,
+                          }));
+                      }}
+                      value={dataSourceUserId}
+                      onChange={(id) => {
+                        const selected = clientUsers.find((u) => u.id === id);
+                        setDataSourceUserId(id);
+                        setStaffDataSourceName(selected?.name ?? '');
+                        setStaffDataSourcePosition(selected?.position ?? '');
+                        setStaffDataSourceSearchLabel(selected?.name ?? '');
+                      }}
+                    />
+                  ) : (
+                    <ReadOnlyField
+                      label="Data Source Name"
+                      value={staffDataSourceName}
+                    />
+                  )}
+                </div>
+                <div className="col-span-2">
+                  <ReadOnlyField
+                    label="Position"
+                    value={staffDataSourcePosition}
+                  />
+                </div>
+              </div>
+            ) : null}
+          </>
+        )}
+
+        {/* ── Lessee / Purchaser Section ── */}
+        <FormSectionHeader title="Lessee" variant="teal" />
+        <div className="p-4 space-y-3">
+          {isEdit ? (
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+              <ReadOnlyField
+                label="Purchaser Type"
+                value={purchaserTypeLabel}
+              />
+              <div className="col-span-3">
+                <ReadOnlyField
+                  label="Purchaser"
+                  value={purchaserLabel || purchaserDisplayLabel || ''}
+                />
+              </div>
+            </div>
+          ) : (
+            <>
+              <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+                <div>
+                  <label className="text-xs font-medium text-slate-600">
+                    Purchaser Type
+                  </label>
+                  <select
+                    {...register('purchaser_type')}
+                    className="mt-1 h-8 w-full rounded border border-slate-300 bg-white px-2 text-sm focus:outline-none focus:border-[#0f7d8e]"
+                    disabled={!partyTypeOptions.length}
+                  >
+                    <option value="">
+                      {partyTypeOptions.length
+                        ? 'Select type...'
+                        : 'Loading types...'}
+                    </option>
+                    {partyTypeOptions.map((option: { value: string; label: string }) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+
+              <div className="rounded border border-slate-200 bg-slate-50 p-3">
+                <p className="mb-2 text-xs font-semibold text-slate-600 uppercase">
+                  Search:{' '}
+                  {watch('purchaser_type') === 'individual'
+                    ? 'Individual'
+                    : 'Company'}
+                </p>
+                <div className="flex gap-2">
+                  <Controller
+                    name="purchaser_id"
+                    control={control}
+                    render={({ field }) => (
+                      <AutocompleteInput
+                        placeholder={
+                          watch('purchaser_type') === 'individual'
+                            ? 'Search by Name / National ID'
+                            : 'Search by Name / Reg Number'
+                        }
+                        queryKey={`hp-purchaser-${watch('purchaser_type')}`}
+                        displayLabel={purchaserLabel}
+                        fetchFn={(q) =>
+                          watch('purchaser_type') === 'company'
+                            ? companiesApi.searchBranches(q)
+                            : individualsApi.searchIndividuals(q)
+                        }
+                        value={field.value}
+                        onBlur={field.onBlur}
+                        error={errors.purchaser_id?.message}
+                        onChange={(v) => field.onChange(Number(v))}
+                      />
+                    )}
+                  />
+                </div>
+              </div>
+            </>
+          )}
         </div>
 
         {/* ── HP Details ── */}
@@ -321,7 +715,7 @@ export function HirePurchaseForm({
               <option value="">
                 {assetTypeOptions.length ? 'Click to select...' : 'Loading...'}
               </option>
-              {assetTypeOptions.map((t: any) => (
+              {assetTypeOptions.map((t: { value: string; label: string }) => (
                 <option key={t.value} value={t.value}>
                   {t.label}
                 </option>
@@ -349,7 +743,7 @@ export function HirePurchaseForm({
               <option value="">
                 {assetConditionOptions.length ? 'Select...' : 'Loading...'}
               </option>
-              {assetConditionOptions.map((c: any) => (
+              {assetConditionOptions.map((c: { value: string; label: string }) => (
                 <option key={c.value} value={c.value}>
                   {c.label}
                 </option>
@@ -357,6 +751,12 @@ export function HirePurchaseForm({
             </select>
           </div>
           <Input label="Serial Number" {...register('reg_serial_number')} />
+          {isVehicle && (
+            <>
+              <Input label="Chassis Number" {...register('chassis_number')} />
+              <Input label="Engine Number" {...register('engine_number')} />
+            </>
+          )}
           <div>
             <label className="text-xs font-medium text-slate-600">
               Currency<span className="text-red-500 ml-0.5">*</span>
@@ -459,7 +859,7 @@ export function HirePurchaseForm({
               Cancel
             </Button>
             <Button type="submit" variant="secondary" loading={isPending}>
-              Save And Exit
+              {isEdit ? 'Save Changes' : 'Save And Exit'}
             </Button>
           </div>
         </div>
@@ -476,6 +876,7 @@ export function HirePurchaseForm({
           onSuccess={({ id, name }) => {
             setValue('purchaser_type', 'individual');
             setValue('purchaser_id', id, { shouldValidate: true });
+            setPurchaserLabel(name);
             setAddIndividualOpen(false);
             toast.success(`${name} added — select from search if needed`);
           }}
@@ -494,6 +895,7 @@ export function HirePurchaseForm({
           onSuccess={({ id, name }) => {
             setValue('purchaser_type', 'company');
             setValue('purchaser_id', id, { shouldValidate: true });
+            setPurchaserLabel(name);
             setAddCompanyOpen(false);
             toast.success(`${name} added — search branch to link purchaser`);
           }}

--- a/frontend/src/components/hire-purchase/HirePurchaseForm.tsx
+++ b/frontend/src/components/hire-purchase/HirePurchaseForm.tsx
@@ -17,6 +17,7 @@ import AutocompleteInput from '@/components/shared/AutocompleteInput';
 import { individualsApi } from '@/api/individualsApi';
 import { companiesApi } from '@/api/companiesApi';
 import { Button } from '@/components/ui/button';
+import { ConfirmDialog } from '@/components/shared/ConfirmDialog';
 import { FormSectionHeader } from '@/components/shared/FormSectionHeader';
 import { FieldError } from '@/components/shared/FieldError';
 import { commonApi } from '@/api/commonApi';
@@ -87,6 +88,10 @@ interface HirePurchaseFormProps {
   onCancel: () => void;
   isEdit?: boolean;
   recordId?: number;
+  /** Edit mode only: invoked when "Close" is clicked, to confirm closure of the record. */
+  onCloseRecord?: () => void;
+  /** Edit mode only: loading state for the closure action. */
+  closurePending?: boolean;
 }
 
 export function HirePurchaseForm({
@@ -100,6 +105,8 @@ export function HirePurchaseForm({
   onCancel,
   isEdit,
   recordId,
+  onCloseRecord,
+  closurePending,
 }: HirePurchaseFormProps) {
   const user = useAuthStore((s) => s.user);
   const setUser = useAuthStore((s) => s.setUser);
@@ -125,10 +132,13 @@ export function HirePurchaseForm({
     purchaserDisplayLabel ?? '',
   );
   const isFirstPurchaserTypeRender = useRef(true);
-  const [dataSourceUserId, setDataSourceUserId] = useState<number | undefined>();
+  const [dataSourceUserId, setDataSourceUserId] = useState<
+    number | undefined
+  >();
   const [staffDataSourceName, setStaffDataSourceName] = useState('');
   const [staffDataSourcePosition, setStaffDataSourcePosition] = useState('');
-  const [staffDataSourceSearchLabel, setStaffDataSourceSearchLabel] = useState('');
+  const [staffDataSourceSearchLabel, setStaffDataSourceSearchLabel] =
+    useState('');
 
   const clearDataSource = () => {
     setDataSourceUserId(undefined);
@@ -140,7 +150,7 @@ export function HirePurchaseForm({
   const { register, control, handleSubmit, watch, reset, setValue, setError } =
     useForm<FormValues>({
       resolver: zodResolver(formSchema),
-      mode: 'onSubmit',
+      mode: 'onBlur',
       reValidateMode: 'onChange',
       shouldFocusError: true,
       defaultValues: {
@@ -217,8 +227,9 @@ export function HirePurchaseForm({
   useEffect(() => {
     if (!currentPurchaserType && partyTypeOptions.length > 0) {
       const defaultPurchaser =
-        partyTypeOptions.find((p: { value: string }) => p.value === 'individual') ||
-        partyTypeOptions[0];
+        partyTypeOptions.find(
+          (p: { value: string }) => p.value === 'individual',
+        ) || partyTypeOptions[0];
       setValue('purchaser_type', defaultPurchaser.value, {
         shouldValidate: true,
       });
@@ -227,7 +238,10 @@ export function HirePurchaseForm({
 
   useEffect(() => {
     if (isStaff || user?.client_id) return;
-    void authApi.me().then(setUser).catch(() => {});
+    void authApi
+      .me()
+      .then(setUser)
+      .catch(() => {});
   }, [isStaff, user?.client_id, setUser]);
 
   useEffect(() => {
@@ -256,7 +270,12 @@ export function HirePurchaseForm({
   }, [selectedFinancierId, isEdit, isClientUser]);
 
   useEffect(() => {
-    if (isEdit || !isStaff || financierClientType !== 'individual' || !clientDetail) {
+    if (
+      isEdit ||
+      !isStaff ||
+      financierClientType !== 'individual' ||
+      !clientDetail
+    ) {
       return;
     }
     const details = clientDetail.client_details;
@@ -306,14 +325,24 @@ export function HirePurchaseForm({
 
   const watchAssetType = watch('asset_type');
   const isVehicle = watchAssetType === 'vehicles';
+  const computedBalance =
+    (watch('purchase_amount') ?? 0) - (watch('total_paid_to_date') ?? 0);
+
+  const [confirmingUpdate, setConfirmingUpdate] = useState(false);
+  const [pendingSubmit, setPendingSubmit] = useState<FormValues | null>(null);
 
   const { mutate: submit, isPending } = useMutation({
     mutationFn: (data: FormValues) =>
       isEdit && recordId
         ? hirePurchaseApi.updateRecord(recordId, data as any)
         : hirePurchaseApi.createRecord(data as any),
-    onSuccess,
+    onSuccess: () => {
+      setConfirmingUpdate(false);
+      setPendingSubmit(null);
+      onSuccess();
+    },
     onError: (err: unknown) => {
+      setConfirmingUpdate(false);
       if (!applyApiValidationErrors(setError, err)) {
         const data = (
           err as { response?: { data?: { message?: string; error?: string } } }
@@ -335,18 +364,37 @@ export function HirePurchaseForm({
         ? ({ ...data, financier_id: clientFinancierId } as StaffFormValues)
         : (data as StaffFormValues);
 
+    const withBalance = {
+      ...payload,
+      balance: (data.purchase_amount ?? 0) - (data.total_paid_to_date ?? 0),
+    };
+
     if (isStaff && !isEdit && dataSourceUserId) {
-      return { ...payload, data_source_user_id: dataSourceUserId };
+      return { ...withBalance, data_source_user_id: dataSourceUserId };
     }
-    return payload;
+    return withBalance;
+  };
+
+  const performSubmit = (
+    data: FormValues,
+    options?: Parameters<typeof submit>[1],
+  ) => {
+    submit(buildSubmitPayload(data) as any, options);
   };
 
   const validateStaffDataSource = () => {
-    if (!isStaff || isEdit || !selectedFinancierId || Number(selectedFinancierId) <= 0) {
+    if (
+      !isStaff ||
+      isEdit ||
+      !selectedFinancierId ||
+      Number(selectedFinancierId) <= 0
+    ) {
       return true;
     }
     if (financierClientType === 'company' && !dataSourceUserId) {
-      toast.error('Please select a data source user for this company financier.');
+      toast.error(
+        'Please select a data source user for this company financier.',
+      );
       return false;
     }
     return true;
@@ -362,8 +410,19 @@ export function HirePurchaseForm({
       }
     }
     if (!validateStaffDataSource()) return;
-    submit(buildSubmitPayload(data) as any);
+    if (isEdit) {
+      setPendingSubmit(data);
+      setConfirmingUpdate(true);
+      return;
+    }
+    performSubmit(data);
   }, onInvalid);
+
+  const handleConfirmUpdate = () => {
+    if (pendingSubmit) {
+      performSubmit(pendingSubmit);
+    }
+  };
 
   const handleSaveAndAdd = handleSubmit((data) => {
     if (isClientUser && !isEdit && !clientFinancierId) {
@@ -374,7 +433,7 @@ export function HirePurchaseForm({
     }
     if (!validateStaffDataSource()) return;
 
-    submit(buildSubmitPayload(data) as any, {
+    performSubmit(data, {
       onSuccess: () => {
         reset();
         clearDataSource();
@@ -434,6 +493,7 @@ export function HirePurchaseForm({
                     onBlur={field.onBlur}
                     error={fieldState.error?.message}
                     required
+                    disabled
                   />
                 )}
               />
@@ -446,7 +506,10 @@ export function HirePurchaseForm({
                 />
               </div>
               <div className="col-span-2">
-                <ReadOnlyField label="Position" value={editDataSourcePosition} />
+                <ReadOnlyField
+                  label="Position"
+                  value={editDataSourcePosition}
+                />
               </div>
             </div>
           </>
@@ -480,6 +543,7 @@ export function HirePurchaseForm({
                     onBlur={field.onBlur}
                     error={fieldState.error?.message}
                     required
+                    disabled
                   />
                 )}
               />
@@ -516,11 +580,13 @@ export function HirePurchaseForm({
                   {partyTypeOptions.length === 0 ? (
                     <option value="company">Loading...</option>
                   ) : (
-                    partyTypeOptions.map((option: { value: string; label: string }) => (
-                      <option key={option.value} value={option.value}>
-                        {option.label}
-                      </option>
-                    ))
+                    partyTypeOptions.map(
+                      (option: { value: string; label: string }) => (
+                        <option key={option.value} value={option.value}>
+                          {option.label}
+                        </option>
+                      ),
+                    )
                   )}
                 </select>
               </div>
@@ -558,6 +624,7 @@ export function HirePurchaseForm({
                     onBlur={field.onBlur}
                     error={fieldState.error?.message}
                     required
+                    disabled
                   />
                 )}
               />
@@ -579,7 +646,8 @@ export function HirePurchaseForm({
                           .filter(
                             (u) =>
                               u.name.toLowerCase().includes(term) ||
-                              (u.position?.toLowerCase().includes(term) ?? false),
+                              (u.position?.toLowerCase().includes(term) ??
+                                false),
                           )
                           .map((u) => ({
                             id: u.id,
@@ -647,11 +715,13 @@ export function HirePurchaseForm({
                         ? 'Select type...'
                         : 'Loading types...'}
                     </option>
-                    {partyTypeOptions.map((option: { value: string; label: string }) => (
-                      <option key={option.value} value={option.value}>
-                        {option.label}
-                      </option>
-                    ))}
+                    {partyTypeOptions.map(
+                      (option: { value: string; label: string }) => (
+                        <option key={option.value} value={option.value}>
+                          {option.label}
+                        </option>
+                      ),
+                    )}
                   </select>
                 </div>
               </div>
@@ -743,11 +813,13 @@ export function HirePurchaseForm({
               <option value="">
                 {assetConditionOptions.length ? 'Select...' : 'Loading...'}
               </option>
-              {assetConditionOptions.map((c: { value: string; label: string }) => (
-                <option key={c.value} value={c.value}>
-                  {c.label}
-                </option>
-              ))}
+              {assetConditionOptions.map(
+                (c: { value: string; label: string }) => (
+                  <option key={c.value} value={c.value}>
+                    {c.label}
+                  </option>
+                ),
+              )}
             </select>
           </div>
           <Input label="Serial Number" {...register('reg_serial_number')} />
@@ -806,12 +878,14 @@ export function HirePurchaseForm({
             step="0.01"
             {...register('total_paid_to_date')}
           />
-          <Input
-            label="Balance"
-            type="number"
-            step="0.01"
-            {...register('balance')}
-          />
+          <div>
+            <label className="text-xs font-medium text-slate-600">
+              Balance
+            </label>
+            <div className="mt-1 flex h-8 w-full items-center rounded border border-slate-200 bg-slate-50 px-2 text-sm text-slate-700">
+              {computedBalance.toFixed(2)}
+            </div>
+          </div>
           <Controller
             name="start_date"
             control={control}
@@ -844,24 +918,42 @@ export function HirePurchaseForm({
 
         {/* ── Footer ── */}
         <div className="flex items-center justify-between border-t border-slate-200 bg-slate-50 px-4 py-3">
-          {!isEdit && (
-            <Button
-              type="button"
-              variant="primary"
-              loading={isPending}
-              onClick={handleSaveAndAdd}
-            >
-              + Save And Add
-            </Button>
+          {isEdit ? (
+            <>
+              <Button type="submit" variant="secondary" loading={isPending}>
+                Update
+              </Button>
+              <Button
+                type="button"
+                variant="danger"
+                loading={closurePending}
+                onClick={onCloseRecord}
+              >
+                Close
+              </Button>
+            </>
+          ) : (
+            <>
+              {!isEdit && (
+                <Button
+                  type="button"
+                  variant="primary"
+                  loading={isPending}
+                  onClick={handleSaveAndAdd}
+                >
+                  + Save And Add
+                </Button>
+              )}
+              <div className="flex gap-2 ml-auto">
+                <Button type="button" variant="ghost" onClick={onCancel}>
+                  Cancel
+                </Button>
+                <Button type="submit" variant="secondary" loading={isPending}>
+                  Save And Exit
+                </Button>
+              </div>
+            </>
           )}
-          <div className="flex gap-2 ml-auto">
-            <Button type="button" variant="ghost" onClick={onCancel}>
-              Cancel
-            </Button>
-            <Button type="submit" variant="secondary" loading={isPending}>
-              {isEdit ? 'Save Changes' : 'Save And Exit'}
-            </Button>
-          </div>
         </div>
       </form>
 
@@ -901,6 +993,20 @@ export function HirePurchaseForm({
           }}
         />
       </Modal>
+
+      <ConfirmDialog
+        open={confirmingUpdate}
+        title="Confirm Update"
+        message="Are you sure you want to save these changes?"
+        confirmLabel="Yes, Update"
+        variant="primary"
+        loading={isPending}
+        onConfirm={handleConfirmUpdate}
+        onCancel={() => {
+          setConfirmingUpdate(false);
+          setPendingSubmit(null);
+        }}
+      />
     </>
   );
 }

--- a/frontend/src/components/hire-purchase/HirePurchaseViewModal.tsx
+++ b/frontend/src/components/hire-purchase/HirePurchaseViewModal.tsx
@@ -9,6 +9,7 @@ import { Button } from '@/components/ui/button';
 import { Edit, CheckCircle } from 'lucide-react';
 import { DeleteRecordButton } from '@/components/shared/DeleteRecordButton';
 import { hirePurchaseApi } from '@/api/hirePurchaseApi';
+import { invalidateRegistryQueries } from '@/lib/registryCache';
 
 interface HirePurchaseViewModalProps {
   record: HirePurchaseRecord;
@@ -31,8 +32,7 @@ export function HirePurchaseViewModal({
     mutationFn: () => hirePurchaseApi.confirmClosure(record.id),
     onSuccess: () => {
       toast.success('Hire purchase closure confirmed');
-      queryClient.invalidateQueries({ queryKey: ['hire-purchase-dashboard'] });
-      queryClient.invalidateQueries({ queryKey: ['hire-purchase'] });
+      invalidateRegistryQueries(queryClient, 'hp');
       setConfirmingClosure(false);
       onSaved();
     },
@@ -55,6 +55,8 @@ export function HirePurchaseViewModal({
           recordId={record.id}
           financierDisplayLabel={record.financier_name}
           purchaserDisplayLabel={record.purchaser_name}
+          dataSourceDisplayLabel={record.data_source_display}
+          dataSourcePositionLabel={record.data_source_position}
           initial={{
             financier_id: record.financier_id,
             data_date: record.data_date,

--- a/frontend/src/components/hire-purchase/HirePurchaseViewModal.tsx
+++ b/frontend/src/components/hire-purchase/HirePurchaseViewModal.tsx
@@ -1,13 +1,13 @@
 import { useState } from 'react';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { Modal } from '@/components/shared/Modal';
+import { ConfirmDialog } from '@/components/shared/ConfirmDialog';
 import { HirePurchaseForm } from './HirePurchaseForm';
 import type { HirePurchaseRecord } from '@/types';
 import { formatCurrency, formatDate } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
-import { Edit, CheckCircle } from 'lucide-react';
-import { DeleteRecordButton } from '@/components/shared/DeleteRecordButton';
+import { Edit } from 'lucide-react';
 import { hirePurchaseApi } from '@/api/hirePurchaseApi';
 import { invalidateRegistryQueries } from '@/lib/registryCache';
 
@@ -15,23 +15,30 @@ interface HirePurchaseViewModalProps {
   record: HirePurchaseRecord;
   onClose: () => void;
   onSaved: () => void;
-  onDeleted: () => void;
 }
 
 export function HirePurchaseViewModal({
   record,
   onClose,
   onSaved,
-  onDeleted,
 }: HirePurchaseViewModalProps) {
   const [editMode, setEditMode] = useState(false);
   const [confirmingClosure, setConfirmingClosure] = useState(false);
   const queryClient = useQueryClient();
 
+  const { data: detail } = useQuery({
+    queryKey: ['hire-purchase-detail', record.id],
+    queryFn: () => hirePurchaseApi.getRecord(record.id),
+    staleTime: 5 * 60 * 1000,
+  });
+
   const { mutate: confirmClosure, isPending: isConfirming } = useMutation({
     mutationFn: () => hirePurchaseApi.confirmClosure(record.id),
     onSuccess: () => {
       toast.success('Hire purchase closure confirmed');
+      queryClient.invalidateQueries({
+        queryKey: ['hire-purchase-detail', record.id],
+      });
       invalidateRegistryQueries(queryClient, 'hp');
       setConfirmingClosure(false);
       onSaved();
@@ -43,118 +50,104 @@ export function HirePurchaseViewModal({
   });
 
   return (
-    <Modal
-      open
-      onClose={onClose}
-      title={`Hire Purchase — ${record.agreement_number}`}
-      size="xl"
-    >
-      {editMode ? (
-        <HirePurchaseForm
-          isEdit
-          recordId={record.id}
-          financierDisplayLabel={record.financier_name}
-          purchaserDisplayLabel={record.purchaser_name}
-          dataSourceDisplayLabel={record.data_source_display}
-          dataSourcePositionLabel={record.data_source_position}
-          initial={{
-            financier_id: record.financier_id,
-            data_date: record.data_date,
-            purchaser_type: record.purchaser_type,
-            purchaser_id: record.purchaser_id,
-            agreement_number: record.agreement_number,
-            asset_type: record.asset_type,
-            asset_make: record.asset_make,
-            asset_model: record.asset_model,
-            asset_year: record.asset_year,
-            asset_condition: record.asset_condition,
-            reg_serial_number: record.reg_serial_number,
-            chassis_number: record.chassis_number,
-            engine_number: record.engine_number,
-            currency: record.currency,
-            purchase_amount: record.purchase_amount,
-            instalment_amount: record.instalment_amount,
-            instalment_date: record.instalment_date,
-            total_paid_to_date: record.total_paid_to_date,
-            balance: record.balance,
-            start_date: record.start_date,
-            end_date: record.end_date,
-          }}
-          onSuccess={onSaved}
-          onCancel={() => setEditMode(false)}
-        />
-      ) : (
-        <div className="p-5 space-y-4 bg-white">
-          <div className="grid grid-cols-2 gap-x-8 gap-y-3 text-sm sm:grid-cols-3">
-            {[
-              ['Financier', record.financier_name],
-              ['Purchaser', record.purchaser_name],
-              ['Agreement No.', record.agreement_number],
-              ['Asset', `${record.asset_make} ${record.asset_model}`],
-              ['Asset Type', record.asset_type],
-              ['Reg/Serial', record.reg_serial_number],
-              ['Currency', record.currency],
-              ['Purchase Amount', formatCurrency(record.purchase_amount)],
-              ['Instalment', formatCurrency(record.instalment_amount)],
-              ['Balance', formatCurrency(record.balance)],
-              ['Start Date', formatDate(record.start_date)],
-              ['End Date', formatDate(record.end_date)],
-              ['Status', record.status],
-            ].map(([k, v]) => (
-              <div key={String(k)}>
-                <dt className="text-xs font-medium uppercase text-slate-400">
-                  {k}
-                </dt>
-                <dd className="mt-0.5 font-medium text-slate-800">
-                  {String(v)}
-                </dd>
-              </div>
-            ))}
-          </div>
-          <div className="flex flex-wrap items-center justify-between gap-2 pt-2 border-t border-slate-100">
-            <DeleteRecordButton
-              onDelete={() => hirePurchaseApi.deleteRecord(record.id)}
-              onDeleted={onDeleted}
+    <>
+      <Modal
+        open
+        onClose={onClose}
+        title={`Hire Purchase — ${record.agreement_number}`}
+        size="xl"
+      >
+        {editMode ? (
+          detail ? (
+            <HirePurchaseForm
+              isEdit
+              recordId={record.id}
+              financierDisplayLabel={detail.financier_name}
+              purchaserDisplayLabel={detail.purchaser_name}
+              dataSourceDisplayLabel={detail.data_source_display}
+              dataSourcePositionLabel={detail.data_source_position}
+              initial={{
+                financier_id: detail.financier_id,
+                data_date: detail.data_date,
+                purchaser_type: detail.purchaser_type,
+                purchaser_id: detail.purchaser_id,
+                agreement_number: detail.agreement_number,
+                asset_type: detail.asset_type,
+                asset_make: detail.asset_make,
+                asset_model: detail.asset_model,
+                asset_year: detail.asset_year,
+                asset_condition: detail.asset_condition,
+                reg_serial_number: detail.reg_serial_number,
+                chassis_number: detail.chassis_number,
+                engine_number: detail.engine_number,
+                currency: detail.currency,
+                purchase_amount: detail.purchase_amount,
+                instalment_amount: detail.instalment_amount,
+                instalment_date: detail.instalment_date,
+                total_paid_to_date: detail.total_paid_to_date,
+                balance: detail.balance,
+                start_date: detail.start_date,
+                end_date: detail.end_date,
+              }}
+              onSuccess={onSaved}
+              onCancel={() => setEditMode(false)}
+              onCloseRecord={() => setConfirmingClosure(true)}
+              closurePending={isConfirming}
             />
-            <div className="flex gap-2 items-center">
-              {record.status !== 'closed' &&
-                (confirmingClosure ? (
-                  <>
-                    <span className="text-xs text-amber-700">
-                      Confirm closure?
-                    </span>
-                    <Button
-                      type="button"
-                      size="sm"
-                      variant="primary"
-                      loading={isConfirming}
-                      onClick={() => confirmClosure()}
-                    >
-                      Yes, Confirm
-                    </Button>
-                    <Button
-                      type="button"
-                      size="sm"
-                      variant="ghost"
-                      onClick={() => setConfirmingClosure(false)}
-                    >
-                      Cancel
-                    </Button>
-                  </>
-                ) : (
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="secondary"
-                    leftIcon={<CheckCircle className="h-3.5 w-3.5" />}
-                    onClick={() => setConfirmingClosure(true)}
-                  >
-                    Confirm Closure
-                  </Button>
-                ))}
-              <Button variant="ghost" onClick={onClose}>
-                Close
-              </Button>
+          ) : (
+            <div className="flex items-center justify-center p-10 text-sm text-slate-400">
+              Loading…
+            </div>
+          )
+        ) : (
+          <div className="p-5 space-y-4 bg-white">
+            <div className="grid grid-cols-2 gap-x-8 gap-y-3 text-sm sm:grid-cols-3">
+              {[
+                ['Financier', detail?.financier_name ?? record.financier_name],
+                ['Purchaser', detail?.purchaser_name ?? record.purchaser_name],
+                ['Agreement No.', record.agreement_number],
+                [
+                  'Asset',
+                  `${detail?.asset_make ?? ''} ${detail?.asset_model ?? ''}`.trim() ||
+                    record.asset_description,
+                ],
+                ['Asset Type', detail?.asset_type ?? record.asset_type],
+                [
+                  'Reg/Serial',
+                  detail?.reg_serial_number || record.reg_serial_number,
+                ],
+                ['Currency', detail?.currency ?? record.currency],
+                [
+                  'Purchase Amount',
+                  formatCurrency(
+                    detail?.purchase_amount ?? record.purchase_amount,
+                  ),
+                ],
+                [
+                  'Instalment',
+                  formatCurrency(
+                    detail?.instalment_amount ?? record.instalment_amount,
+                  ),
+                ],
+                ['Balance', formatCurrency(detail?.balance ?? record.balance)],
+                [
+                  'Start Date',
+                  formatDate(detail?.start_date ?? record.start_date),
+                ],
+                ['End Date', formatDate(detail?.end_date ?? record.end_date)],
+                ['Status', detail?.status ?? record.status],
+              ].map(([k, v]) => (
+                <div key={String(k)}>
+                  <dt className="text-xs font-medium uppercase text-slate-400">
+                    {k}
+                  </dt>
+                  <dd className="mt-0.5 font-medium text-slate-800">
+                    {String(v ?? '—')}
+                  </dd>
+                </div>
+              ))}
+            </div>
+            <div className="flex items-center justify-end gap-2 pt-2 border-t border-slate-100">
               <Button
                 leftIcon={<Edit className="h-3.5 w-3.5" />}
                 onClick={() => setEditMode(true)}
@@ -163,8 +156,19 @@ export function HirePurchaseViewModal({
               </Button>
             </div>
           </div>
-        </div>
-      )}
-    </Modal>
+        )}
+      </Modal>
+
+      <ConfirmDialog
+        open={confirmingClosure}
+        title="Close Hire Purchase Agreement"
+        message="Are you sure you want to close this hire purchase agreement?"
+        confirmLabel="Yes, Confirm"
+        variant="danger"
+        loading={isConfirming}
+        onConfirm={() => confirmClosure()}
+        onCancel={() => setConfirmingClosure(false)}
+      />
+    </>
   );
 }

--- a/frontend/src/components/layout/SidebarUserMenu.tsx
+++ b/frontend/src/components/layout/SidebarUserMenu.tsx
@@ -1,8 +1,14 @@
-import { useEffect, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
+import { createPortal } from 'react-dom';
 import { LogOut, UserCircle } from 'lucide-react';
 import { useAuth } from '@/hooks/useAuth';
 import { useAuthStore } from '@/store';
-import { cn } from '@/lib/utils';
 import {
   SidebarMenu,
   SidebarMenuButton,
@@ -10,25 +16,127 @@ import {
   useSidebar,
 } from '@/components/ui/sidebar';
 
+type MenuPosition = {
+  top: number;
+  left: number;
+  transform: string;
+};
+
 export function SidebarUserMenu() {
   const { user } = useAuthStore();
   const { logout } = useAuth();
   const { state, isMobile } = useSidebar();
   const [open, setOpen] = useState(false);
+  const [menuPosition, setMenuPosition] = useState<MenuPosition | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
   const collapsed = state === 'collapsed' && !isMobile;
 
   const displayName = user?.name || user?.username || 'User';
 
+  const updateMenuPosition = useCallback(() => {
+    const el = containerRef.current;
+    if (!el) {
+      return;
+    }
+
+    const rect = el.getBoundingClientRect();
+    setMenuPosition(
+      collapsed
+        ? {
+            // Match original collapsed placement: to the right, bottom-aligned.
+            top: rect.bottom,
+            left: rect.right + 8,
+            transform: 'translateY(-100%)',
+          }
+        : {
+            top: rect.top - 8,
+            left: rect.left,
+            transform: 'translateY(-100%)',
+          },
+    );
+  }, [collapsed]);
+
+  useLayoutEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    updateMenuPosition();
+    window.addEventListener('resize', updateMenuPosition);
+    window.addEventListener('scroll', updateMenuPosition, true);
+
+    return () => {
+      window.removeEventListener('resize', updateMenuPosition);
+      window.removeEventListener('scroll', updateMenuPosition, true);
+    };
+  }, [open, updateMenuPosition]);
+
+  useEffect(() => {
+    if (!open) {
+      setMenuPosition(null);
+    }
+  }, [open]);
+
   useEffect(() => {
     function onDocClick(e: MouseEvent) {
-      if (!containerRef.current?.contains(e.target as Node)) {
-        setOpen(false);
+      const target = e.target as Node;
+      if (
+        containerRef.current?.contains(target) ||
+        menuRef.current?.contains(target)
+      ) {
+        return;
       }
+      setOpen(false);
     }
+
     document.addEventListener('mousedown', onDocClick);
     return () => document.removeEventListener('mousedown', onDocClick);
   }, []);
+
+  const handleToggle = () => {
+    setOpen((v) => !v);
+  };
+
+  const menu =
+    open && menuPosition
+      ? createPortal(
+          <div
+            ref={menuRef}
+            role="menu"
+            className="fixed z-[200] min-w-[220px] border border-[#8f8f8f] bg-white py-2 shadow-lg"
+            style={{
+              top: menuPosition.top,
+              left: menuPosition.left,
+              transform: menuPosition.transform,
+            }}
+          >
+            <div className="border-b border-slate-200 px-4 py-3">
+              <p className="text-sm font-semibold text-slate-900">
+                {displayName}
+              </p>
+              {user?.email ? (
+                <p className="mt-0.5 truncate text-xs text-slate-500">
+                  {user.email}
+                </p>
+              ) : null}
+            </div>
+            <button
+              type="button"
+              role="menuitem"
+              className="flex w-full cursor-pointer items-center gap-2 px-4 py-2.5 text-sm font-medium text-[#c62828] hover:bg-red-100"
+              onClick={async () => {
+                setOpen(false);
+                await logout();
+              }}
+            >
+              <LogOut className="h-4 w-4" />
+              Logout
+            </button>
+          </div>,
+          document.body,
+        )
+      : null;
 
   return (
     <SidebarMenu>
@@ -38,7 +146,7 @@ export function SidebarUserMenu() {
             type="button"
             size="lg"
             tooltip={displayName}
-            onClick={() => setOpen((v) => !v)}
+            onClick={handleToggle}
             aria-expanded={open}
             aria-haspopup="menu"
             className="group-data-[collapsible=icon]:justify-center"
@@ -50,41 +158,7 @@ export function SidebarUserMenu() {
               {displayName}
             </span>
           </SidebarMenuButton>
-
-          {open ? (
-            <div
-              role="menu"
-              className={cn(
-                'absolute z-50 min-w-[220px] border border-[#8f8f8f] bg-white py-2 shadow-lg',
-                collapsed
-                  ? 'bottom-0 left-full ml-2'
-                  : 'bottom-full left-0 mb-2',
-              )}
-            >
-              <div className="border-b border-slate-200 px-4 py-3">
-                <p className="text-sm font-semibold text-slate-900">
-                  {displayName}
-                </p>
-                {user?.email ? (
-                  <p className="mt-0.5 truncate text-xs text-slate-500">
-                    {user.email}
-                  </p>
-                ) : null}
-              </div>
-              <button
-                type="button"
-                role="menuitem"
-                className="flex w-full items-center gap-2 px-4 py-2.5 text-sm font-medium text-slate-800 hover:bg-slate-50"
-                onClick={async () => {
-                  setOpen(false);
-                  await logout();
-                }}
-              >
-                <LogOut className="h-4 w-4" />
-                Logout
-              </button>
-            </div>
-          ) : null}
+          {menu}
         </div>
       </SidebarMenuItem>
     </SidebarMenu>

--- a/frontend/src/components/registry/AssetRegistryForm.tsx
+++ b/frontend/src/components/registry/AssetRegistryForm.tsx
@@ -68,7 +68,7 @@ export function AssetRegistryForm({
   const { register, control, handleSubmit, watch, setValue, setError } =
     useForm<FormValues>({
       resolver: zodResolver(schema),
-      mode: 'onSubmit',
+      mode: 'onBlur',
       reValidateMode: 'onChange',
       shouldFocusError: true,
       defaultValues: {

--- a/frontend/src/components/shared/ConfirmDialog.tsx
+++ b/frontend/src/components/shared/ConfirmDialog.tsx
@@ -1,0 +1,68 @@
+import { Modal } from './Modal';
+import { Button } from '@/components/ui/button';
+
+interface ConfirmDialogProps {
+  open: boolean;
+  title?: string;
+  message: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  variant?: 'danger' | 'primary' | 'secondary' | 'success';
+  loading?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+/**
+ * App-styled replacement for the browser's native `window.confirm()`, so
+ * confirmation prompts match the rest of the UI instead of looking like a
+ * stock OS alert box.
+ *
+ * Render as a sibling of other modals (not nested inside them) so the
+ * backdrop and z-index behave correctly.
+ */
+export function ConfirmDialog({
+  open,
+  title = 'Please Confirm',
+  message,
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+  variant = 'danger',
+  loading = false,
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  if (!open) return null;
+
+  return (
+    <Modal
+      open={open}
+      onClose={loading ? () => {} : onCancel}
+      title={title}
+      size="sm"
+      disableBackdropClose
+    >
+      <div className="space-y-4 bg-white p-5">
+        <p className="text-sm leading-relaxed text-slate-700">{message}</p>
+        <div className="flex items-center justify-end gap-2 border-t border-slate-200 pt-3">
+          <Button
+            type="button"
+            variant="ghost"
+            disabled={loading}
+            onClick={onCancel}
+          >
+            {cancelLabel}
+          </Button>
+          <Button
+            type="button"
+            variant={variant}
+            loading={loading}
+            onClick={onConfirm}
+          >
+            {confirmLabel}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/components/shared/InlineStat.tsx
+++ b/frontend/src/components/shared/InlineStat.tsx
@@ -1,15 +1,23 @@
+import { cn } from '@/lib/utils';
+
 interface InlineStatProps {
   label: string;
   value: string | number;
+  valueClassName?: string;
 }
 
-export function InlineStat({ label, value }: InlineStatProps) {
+export function InlineStat({ label, value, valueClassName }: InlineStatProps) {
   return (
-    <div className="flex items-baseline gap-2 border-r border-[#8f8f8f] pr-4 last:border-r-0">
-      <span className="text-[11px] font-semibold uppercase tracking-wide text-slate-600">
+    <div className="flex items-center gap-2 border-r border-[#8f8f8f] pr-4 last:border-r-0">
+      <span className="shrink-0 text-[11px] font-semibold uppercase tracking-wide text-slate-600">
         {label}
       </span>
-      <span className="text-lg font-black leading-none text-[#c62828]">
+      <span
+        className={cn(
+          'whitespace-nowrap text-lg font-black tabular-nums leading-snug text-[#c62828]',
+          valueClassName,
+        )}
+      >
         {value}
       </span>
     </div>

--- a/frontend/src/components/shared/LocationCascadeSelects.tsx
+++ b/frontend/src/components/shared/LocationCascadeSelects.tsx
@@ -1,8 +1,13 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { locationsApi } from '@/api/locationsApi';
+import type {
+  CityOption,
+  CountryOption,
+  SuburbOption,
+} from '@/api/locationsApi';
 import { FieldError } from './FieldError';
-import { queryOptions } from '@/api/queryOptions';
+import { cn } from '@/lib/utils';
 
 interface Props {
   value?: number;
@@ -10,108 +15,342 @@ interface Props {
   error?: string;
 }
 
+// ─── Generic searchable combobox ──────────────────────────────────────────────
+
+interface ComboboxProps<T extends { id: number; name: string }> {
+  label: string;
+  required?: boolean;
+  placeholder: string;
+  options: T[];
+  selected: T | null;
+  onSelect: (item: T | null) => void;
+  error?: string;
+  isLoading?: boolean;
+}
+
+function Combobox<T extends { id: number; name: string }>({
+  label,
+  required,
+  placeholder,
+  options,
+  selected,
+  onSelect,
+  error,
+  isLoading,
+}: ComboboxProps<T>) {
+  const [query, setQuery] = useState('');
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  // Keep display text in sync when selection is set externally (auto-populate)
+  useEffect(() => {
+    setQuery(selected?.name ?? '');
+  }, [selected]);
+
+  useEffect(() => {
+    function handler(e: MouseEvent) {
+      if (!ref.current?.contains(e.target as Node)) setOpen(false);
+    }
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, []);
+
+  const filtered = query.trim()
+    ? options.filter((o) =>
+        o.name.toLowerCase().includes(query.toLowerCase().trim()),
+      )
+    : options;
+
+  return (
+    <div ref={ref} className="relative">
+      <label className="text-xs font-medium text-slate-600">
+        {label}
+        {required && <span className="ml-0.5 text-red-500">*</span>}
+      </label>
+      <input
+        value={query}
+        placeholder={placeholder}
+        autoComplete="off"
+        onFocus={() => setOpen(true)}
+        onChange={(e) => {
+          const val = e.target.value;
+          setQuery(val);
+          setOpen(true);
+          // Only propagate a deselect when the field is fully cleared.
+          // Typing must NOT clear downstream selections.
+          if (val === '') onSelect(null);
+        }}
+        className={cn(
+          'mt-1 h-8 w-full rounded border bg-white px-2 text-sm focus:outline-none focus:border-[#0f7d8e]',
+          error ? 'border-red-500' : 'border-slate-300',
+        )}
+      />
+      {open && (
+        <div className="absolute z-[70] mt-0.5 max-h-52 w-full overflow-auto rounded border border-slate-300 bg-white shadow-md">
+          {isLoading ? (
+            <p className="px-3 py-2 text-sm text-slate-400">Loading…</p>
+          ) : filtered.length === 0 ? (
+            <p className="px-3 py-2 text-sm text-slate-400">No results</p>
+          ) : (
+            filtered.map((item) => (
+              <button
+                key={item.id}
+                type="button"
+                className="block w-full px-3 py-2 text-left text-sm hover:bg-slate-100"
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => {
+                  onSelect(item);
+                  setOpen(false);
+                }}
+              >
+                {item.name}
+              </button>
+            ))
+          )}
+        </div>
+      )}
+      <FieldError message={error} />
+    </div>
+  );
+}
+
+// ─── LocationCascadeSelects ───────────────────────────────────────────────────
+
+const STATIC = { staleTime: Infinity, gcTime: Infinity, retry: false } as const;
+
+function sorted<T extends { name: string }>(arr: T[]): T[] {
+  return [...arr].sort((a, b) => a.name.localeCompare(b.name));
+}
+
 export function LocationCascadeSelects({ value, onChange, error }: Props) {
-  const [countryId, setCountryId] = useState<number | ''>('');
-  const [cityId, setCityId] = useState<number | ''>('');
+  const [country, setCountry] = useState<CountryOption | null>(null);
+  const [city, setCity] = useState<CityOption | null>(null);
+  const [suburb, setSuburb] = useState<SuburbOption | null>(null);
 
-  const { data: countries = [] } = useQuery({
-    queryKey: ['countries'],
+  // ── base data — loaded once on mount, cached forever ─────────────────────
+  //
+  // Four parallel fetches start immediately so data is ready before the user
+  // opens any dropdown.
+  //
+  //  countries    → CountryOption[]                       always loaded
+  //  allProvinces → ProvinceOption[]  province_name → country_name bridge
+  //  allCities    → CityOption[]      province_name carried so we can map → country
+  //  allSuburbs   → SuburbOption[]    from SuburbViewSet (/common/suburbs/)
+  //                                   carries city_name + country_name strings
+
+  const { data: countries = [], isLoading: loadingCountries } = useQuery({
+    queryKey: ['loc-countries'],
     queryFn: locationsApi.getCountries,
-    ...queryOptions.static,
+    ...STATIC,
+  });
+  const { data: allProvinces = [] } = useQuery({
+    queryKey: ['loc-provinces-all'],
+    queryFn: locationsApi.getProvinces,
+    ...STATIC,
+  });
+  const { data: allCities = [], isLoading: loadingCities } = useQuery({
+    queryKey: ['loc-cities-all'],
+    queryFn: () => locationsApi.getCities(),
+    ...STATIC,
+  });
+  const { data: allSuburbs = [], isLoading: loadingSuburbs } = useQuery({
+    queryKey: ['loc-suburbs-view'],
+    queryFn: locationsApi.getAllSuburbsWithHierarchy,
+    ...STATIC,
   });
 
-  const { data: cities = [] } = useQuery({
-    queryKey: ['cities', countryId],
-    queryFn: () => locationsApi.getCities(Number(countryId)),
-    enabled: !!countryId,
-    ...queryOptions.static,
-  });
+  // ── filtered pools — one fetch per unique id, then cached forever ─────────
 
-  const { data: suburbs = [] } = useQuery({
-    queryKey: ['suburbs', cityId],
-    queryFn: () => locationsApi.getSuburbs(Number(cityId)),
-    enabled: !!cityId,
-    ...queryOptions.static,
-  });
+  const { data: citiesForCountry = [], isLoading: loadingCitiesForCountry } =
+    useQuery({
+      queryKey: ['loc-cities', country?.id],
+      queryFn: () => locationsApi.getCities(country!.id),
+      enabled: !!country,
+      ...STATIC,
+    });
 
-  const selectClass =
-    'mt-1 h-8 w-full rounded border border-slate-300 bg-white px-2 text-sm focus:outline-none focus:border-[#0f7d8e] disabled:bg-slate-100 disabled:cursor-not-allowed';
+  // suburbsForCity has city_id injected at the API layer — reliable auto-populate source.
+  const { data: suburbsForCity = [], isLoading: loadingSuburbsForCity } =
+    useQuery({
+      queryKey: ['loc-suburbs', city?.id],
+      queryFn: () => locationsApi.getSuburbs(city!.id),
+      enabled: !!city,
+      ...STATIC,
+    });
+
+  // ── lookup helpers ───────────────────────────────────────────────────────
+
+  const findCountry = (name: string | undefined) =>
+    name ? (countries.find((c) => c.name === name) ?? null) : null;
+
+  const findCity = (name: string | undefined) =>
+    name ? (allCities.find((c) => c.name === name) ?? null) : null;
+
+  /** province_name → country_name via allProvinces */
+  const countryNameForCity = (c: CityOption) =>
+    allProvinces.find((p) => p.name === c.province_name)?.country_name;
+
+  // ── reactive auto-populate ────────────────────────────────────────────────
+  //
+  // Effects run whenever the selection OR the backing data changes.
+  // This means auto-populate will succeed even on slow connections where
+  // allCities / allProvinces arrive after the user has already selected.
+
+  // suburb selected → fill city (uses city_id when available, otherwise city_name match)
+  useEffect(() => {
+    if (!suburb || city) return;
+    if (allCities.length === 0) return;
+
+    const found =
+      suburb.city_id != null
+        ? (allCities.find((c) => c.id === suburb.city_id) ?? null)
+        : suburb.city_name
+          ? (allCities.find((c) => c.name === suburb.city_name) ?? null)
+          : null;
+
+    if (found) setCity(found);
+  }, [suburb, city, allCities]);
+
+  // city known → fill country
+  // Strategy: find any suburb whose city_name matches the selected city —
+  // that suburb carries country_name directly from SuburbViewSerializer.
+  // Falls back to province chain if allSuburbs not loaded yet.
+  useEffect(() => {
+    if (!city || country) return;
+    if (countries.length === 0) return;
+
+    // Primary: look up country_name via allSuburbs (city_name → country_name)
+    if (allSuburbs.length > 0) {
+      const sample = allSuburbs.find((s) => s.city_name === city.name);
+      if (sample?.country_name) {
+        const found =
+          countries.find((c) => c.name === sample.country_name) ?? null;
+        if (found) {
+          setCountry(found);
+          return;
+        }
+      }
+    }
+
+    // Fallback: province chain (city.province_name → province.country_name)
+    if (allProvinces.length > 0) {
+      const province = allProvinces.find((p) => p.name === city.province_name);
+      if (province?.country_name) {
+        const found =
+          countries.find((c) => c.name === province.country_name) ?? null;
+        if (found) setCountry(found);
+      }
+    }
+  }, [city, country, allSuburbs, allProvinces, countries]);
+
+  // suburb known → fill country directly from suburb.country_name
+  useEffect(() => {
+    if (!suburb || country) return;
+    if (countries.length === 0 || !suburb.country_name) return;
+
+    const found = countries.find((c) => c.name === suburb.country_name) ?? null;
+    if (found) setCountry(found);
+  }, [suburb, country, countries]);
+
+  // ── derived option lists ──────────────────────────────────────────────────
+  //
+  // Suburb pool priority:
+  //   city selected    → suburbsForCity (API-filtered, city_id injected)
+  //   country selected → allSuburbs filtered by country_name  ← simple O(n), reliable
+  //   nothing selected → allSuburbs (everything)
+  //
+  // City pool:
+  //   country selected → citiesForCountry (API-filtered)
+  //   nothing selected → allCities
+
+  const countryOptions = sorted(countries);
+
+  const cityOptions = sorted(country ? citiesForCountry : allCities);
+
+  const suburbOptions = sorted(
+    city
+      ? suburbsForCity
+      : country
+        ? allSuburbs.filter((s) => s.country_name === country.name)
+        : allSuburbs,
+  );
+
+  // ── handlers ─────────────────────────────────────────────────────────────
+  //
+  // Clearing rules:
+  //   Typing in a field   → never clears downstream (only onSelect(null) clears)
+  //   Field fully erased  → clear that level only; others stay
+  //   New country chosen  → clear city+suburb only if they no longer belong
+  //   New city chosen     → always clear suburb (belongs to a new pool)
+
+  const handleCountrySelect = (item: CountryOption | null) => {
+    setCountry(item);
+    if (!item) return; // erased — leave city & suburb intact
+
+    if (city) {
+      // Check whether the current city belongs to the new country
+      const cityCountryName = countryNameForCity(city);
+      const stillValid =
+        cityCountryName === item.name ||
+        citiesForCountry.some((c) => c.id === city.id);
+
+      if (!stillValid) {
+        setCity(null);
+        setSuburb(null);
+        onChange(0);
+      }
+    }
+  };
+
+  const handleCitySelect = (item: CityOption | null) => {
+    setCity(item);
+    if (!item) return; // erased — leave suburb intact
+
+    // New city explicitly chosen → reset suburb (different suburb pool)
+    setSuburb(null);
+    onChange(0);
+    // country will be filled reactively by the useEffect above
+  };
+
+  const handleSuburbSelect = (item: SuburbOption | null) => {
+    setSuburb(item);
+    onChange(item?.id ?? 0);
+    if (!item) {
+      // Suburb cleared → reset city and country too
+      setCity(null);
+      setCountry(null);
+    }
+    // When item is set, city & country fill reactively via the useEffects above
+  };
 
   return (
     <>
-      <div>
-        <label className="text-xs font-medium text-slate-600">Country</label>
-        <select
-          value={countryId}
-          onChange={(e) => {
-            setCountryId(Number(e.target.value) || '');
-            setCityId('');
-            onChange(0);
-          }}
-          className={selectClass}
-        >
-          <option value="">
-            {countries.length ? 'Select country…' : 'Loading…'}
-          </option>
-          {countries.map((c) => (
-            <option key={c.id} value={c.id}>
-              {c.name}
-            </option>
-          ))}
-        </select>
-      </div>
-
-      <div>
-        <label className="text-xs font-medium text-slate-600">City</label>
-        <select
-          value={cityId}
-          disabled={!countryId}
-          onChange={(e) => {
-            setCityId(Number(e.target.value) || '');
-            onChange(0);
-          }}
-          className={selectClass}
-        >
-          <option value="">
-            {!countryId
-              ? 'Select country first'
-              : cities.length
-                ? 'Select city…'
-                : 'Loading…'}
-          </option>
-          {cities.map((c) => (
-            <option key={c.id} value={c.id}>
-              {c.name}
-            </option>
-          ))}
-        </select>
-      </div>
-
-      <div>
-        <label className="text-xs font-medium text-slate-600">
-          Suburb<span className="text-red-500 ml-0.5">*</span>
-        </label>
-        <select
-          value={value || ''}
-          disabled={!cityId}
-          onChange={(e) => onChange(Number(e.target.value))}
-          className={selectClass}
-        >
-          <option value="">
-            {!cityId
-              ? 'Select city first'
-              : suburbs.length
-                ? 'Select suburb…'
-                : 'Loading…'}
-          </option>
-          {suburbs.map((s) => (
-            <option key={s.id} value={s.id}>
-              {s.name}
-            </option>
-          ))}
-        </select>
-        <FieldError message={error} />
-      </div>
+      <Combobox<SuburbOption>
+        label="Suburb"
+        required
+        placeholder="Search suburb…"
+        options={suburbOptions}
+        selected={suburb}
+        onSelect={handleSuburbSelect}
+        error={error}
+        isLoading={city ? loadingSuburbsForCity : loadingSuburbs}
+      />
+      <Combobox<CityOption>
+        label="City"
+        placeholder="Search city…"
+        options={cityOptions}
+        selected={city}
+        onSelect={handleCitySelect}
+        isLoading={country ? loadingCitiesForCountry : loadingCities}
+      />
+      <Combobox<CountryOption>
+        label="Country"
+        placeholder="Search country…"
+        options={countryOptions}
+        selected={country}
+        onSelect={handleCountrySelect}
+        isLoading={loadingCountries}
+      />
     </>
   );
 }

--- a/frontend/src/components/ui/DateInput.tsx
+++ b/frontend/src/components/ui/DateInput.tsx
@@ -1,23 +1,5 @@
-import React, { useState, useEffect } from 'react';
-import * as Popover from '@radix-ui/react-popover';
-import { DayPicker } from 'react-day-picker';
-import { format, parse, isValid } from 'date-fns';
-import { CalendarIcon } from 'lucide-react';
+import React from 'react';
 import { cn } from '@/lib/utils';
-import 'react-day-picker/style.css';
-
-function toDisplay(iso: string): string {
-  if (!iso || !/^\d{4}-\d{2}-\d{2}$/.test(iso)) return '';
-  const [y, m, d] = iso.split('-');
-  return `${d}/${m}/${y}`;
-}
-
-function toISO(display: string): string {
-  const match = display.match(/^(\d{2})\/(\d{2})\/(\d{4})$/);
-  if (!match) return '';
-  const [, d, m, y] = match;
-  return `${y}-${m}-${d}`;
-}
 
 interface DateInputProps {
   label?: string;
@@ -29,55 +11,32 @@ interface DateInputProps {
   name?: string;
   disabled?: boolean;
   id?: string;
+  min?: string;
+  max?: string;
 }
 
 const MAX_DATE_YEAR = new Date().getFullYear() + 10;
 
 export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
   (
-    { label, error, required, value, onChange, onBlur, name, disabled, id },
-    _ref,
+    {
+      label,
+      error,
+      required,
+      value,
+      onChange,
+      onBlur,
+      name,
+      disabled,
+      id,
+      min = '1990-01-01',
+      max = `${MAX_DATE_YEAR}-12-31`,
+    },
+    ref,
   ) => {
-    const [display, setDisplay] = useState(() => toDisplay(value ?? ''));
-    const [open, setOpen] = useState(false);
-
-    useEffect(() => {
-      setDisplay(toDisplay(value ?? ''));
-    }, [value]);
-
     const inputId = id ?? label?.toLowerCase().replace(/\s+/g, '-');
-
-    const selectedDate: Date | undefined = (() => {
-      if (value && /^\d{4}-\d{2}-\d{2}$/.test(value)) {
-        const d = new Date(value + 'T00:00:00');
-        return isValid(d) ? d : undefined;
-      }
-      return undefined;
-    })();
-
-    const handleTextChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-      let digits = e.target.value.replace(/\D/g, '');
-      if (digits.length > 8) digits = digits.slice(0, 8);
-
-      let formatted = digits;
-      if (digits.length > 4) {
-        formatted = `${digits.slice(0, 2)}/${digits.slice(2, 4)}/${digits.slice(4)}`;
-      } else if (digits.length > 2) {
-        formatted = `${digits.slice(0, 2)}/${digits.slice(2)}`;
-      }
-
-      setDisplay(formatted);
-      onChange?.(toISO(formatted));
-    };
-
-    const handleDaySelect = (day: Date | undefined) => {
-      if (!day) return;
-      const iso = format(day, 'yyyy-MM-dd');
-      const disp = format(day, 'dd/MM/yyyy');
-      setDisplay(disp);
-      onChange?.(iso);
-      setOpen(false);
-    };
+    const isoValue =
+      value && /^\d{4}-\d{2}-\d{2}$/.test(value) ? value : '';
 
     return (
       <div className="flex flex-col gap-1">
@@ -90,80 +49,27 @@ export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
             {required && <span className="text-red-500 ml-0.5">*</span>}
           </label>
         )}
-        <div className="relative flex items-center">
-          <input
-            id={inputId}
-            name={name}
-            type="text"
-            inputMode="numeric"
-            placeholder="dd/mm/yyyy"
-            value={display}
-            onChange={handleTextChange}
-            onBlur={onBlur}
-            disabled={disabled}
-            maxLength={10}
-            className={cn(
-              'h-8 w-full rounded-sm border border-slate-500 bg-white pl-2.5 pr-8 text-sm text-slate-900',
-              'placeholder:text-slate-400 focus:border-black focus:outline-none focus:ring-0',
-              'disabled:cursor-not-allowed disabled:bg-slate-100',
-              error && 'border-red-500 focus:border-red-500',
-            )}
-          />
-          <Popover.Root open={open} onOpenChange={setOpen}>
-            <Popover.Trigger asChild>
-              <button
-                type="button"
-                disabled={disabled}
-                className="absolute right-1.5 flex h-5 w-5 items-center justify-center rounded text-slate-400 hover:text-slate-700 disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                <CalendarIcon className="h-3.5 w-3.5" />
-              </button>
-            </Popover.Trigger>
-            <Popover.Portal>
-              <Popover.Content
-                align="start"
-                sideOffset={6}
-                className="z-[9999] rounded border border-slate-200 bg-white shadow-lg"
-              >
-                <DayPicker
-                  mode="single"
-                  selected={selectedDate}
-                  onSelect={handleDaySelect}
-                  defaultMonth={selectedDate ?? new Date()}
-                  captionLayout="dropdown"
-                  startMonth={new Date(1990, 0)}
-                  endMonth={new Date(MAX_DATE_YEAR, 11)}
-                  classNames={{
-                    root: 'p-3 text-sm',
-                    month_caption:
-                      'flex items-center justify-between mb-2 px-1',
-                    dropdowns: 'flex gap-1',
-                    dropdown:
-                      'rounded border border-slate-300 bg-white px-1 py-0.5 text-xs',
-                    nav: 'flex gap-1',
-                    button_previous: 'rounded p-1 hover:bg-slate-100',
-                    button_next: 'rounded p-1 hover:bg-slate-100',
-                    month_grid: 'w-full border-collapse',
-                    weekdays: 'flex',
-                    weekday:
-                      'w-8 text-center text-xs text-slate-400 font-normal pb-1',
-                    weeks: '',
-                    week: 'flex',
-                    day: 'w-8 h-8 flex items-center justify-center',
-                    day_button:
-                      'w-8 h-8 rounded text-xs hover:bg-slate-100 focus:outline-none',
-                    selected:
-                      '[&>button]:bg-[#0f7d8e] [&>button]:text-white [&>button]:hover:bg-[#0c6a79]',
-                    today: '[&>button]:font-bold [&>button]:text-[#0f7d8e]',
-                    outside: 'opacity-30',
-                    disabled: 'opacity-30 cursor-not-allowed',
-                  }}
-                />
-                <Popover.Arrow className="fill-slate-200" />
-              </Popover.Content>
-            </Popover.Portal>
-          </Popover.Root>
-        </div>
+        <input
+          ref={ref}
+          id={inputId}
+          name={name}
+          type="date"
+          value={isoValue}
+          min={min}
+          max={max}
+          onChange={(e) => onChange?.(e.target.value)}
+          onBlur={onBlur}
+          disabled={disabled}
+          className={cn(
+            'h-8 w-full rounded-sm border border-slate-500 bg-white px-2.5 text-sm text-slate-900',
+            'focus:border-black focus:outline-none focus:ring-0',
+            'disabled:cursor-not-allowed disabled:bg-slate-100',
+            '[&::-webkit-calendar-picker-indicator]:cursor-pointer',
+            '[&::-webkit-calendar-picker-indicator]:opacity-60',
+            '[&::-webkit-calendar-picker-indicator]:hover:opacity-100',
+            error && 'border-red-500 focus:border-red-500',
+          )}
+        />
         {error && <p className="text-xs text-red-500">{error}</p>}
       </div>
     );

--- a/frontend/src/lib/formErrors.ts
+++ b/frontend/src/lib/formErrors.ts
@@ -1,4 +1,9 @@
-import type { FieldValues, Path, UseFormSetError } from 'react-hook-form';
+import type {
+  FieldErrors,
+  FieldValues,
+  Path,
+  UseFormSetError,
+} from 'react-hook-form';
 
 /** Maps API / serializer field names to form field names. */
 const API_FIELD_MAP: Record<string, string> = {
@@ -91,4 +96,19 @@ export function applyApiValidationErrors<T extends FieldValues>(
   }
 
   return true;
+}
+
+/** Returns the first validation message from a react-hook-form errors object. */
+export function firstFormErrorMessage(
+  errors: FieldErrors,
+): string | undefined {
+  for (const value of Object.values(errors)) {
+    if (!value || typeof value !== 'object') continue;
+    if ('message' in value && typeof value.message === 'string') {
+      return value.message;
+    }
+    const nested = firstFormErrorMessage(value as FieldErrors);
+    if (nested) return nested;
+  }
+  return undefined;
 }

--- a/frontend/src/lib/registryNav.ts
+++ b/frontend/src/lib/registryNav.ts
@@ -3,9 +3,9 @@ import type { AuthUser } from '@/api/authApi';
 export const ASSET_REGISTRY_PATH = '/registry';
 
 export const REGISTRY_DASHBOARD_TABS = [
-  { label: 'Asset', path: ASSET_REGISTRY_PATH, staffOnly: true },
   { label: 'Collateral', path: '/collateral', staffOnly: false },
   { label: 'HP', path: '/hire-purchase', staffOnly: false },
+  { label: 'Registry', path: ASSET_REGISTRY_PATH, staffOnly: true },
 ] as const;
 
 export function isStaffUser(user: AuthUser | null | undefined): boolean {

--- a/frontend/src/lib/registryPayloads.ts
+++ b/frontend/src/lib/registryPayloads.ts
@@ -103,5 +103,8 @@ export function mapHirePurchaseFormToApi(data: Record<string, unknown>) {
     balance: data.balance,
     agreement_start_date: data.start_date,
     agreement_end_date: data.end_date,
+    ...(data.data_source_user_id
+      ? { data_source_user_id: data.data_source_user_id }
+      : {}),
   };
 }

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -16,6 +16,15 @@ export function formatCurrency(
   }).format(value);
 }
 
+export function formatDollarAmount(value: number): string {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
 export function formatDate(dateStr: string): string {
   if (!dateStr) return '';
   const d = new Date(dateStr);

--- a/frontend/src/pages/AssetRegistryPage.tsx
+++ b/frontend/src/pages/AssetRegistryPage.tsx
@@ -1,7 +1,14 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
-import { ArrowDown, ArrowUp, ArrowUpDown, Plus, Search } from 'lucide-react';
+import {
+  ArrowDown,
+  ArrowUp,
+  ArrowUpDown,
+  Layers,
+  Plus,
+  Search,
+} from 'lucide-react';
 import { assetRegistryApi } from '@/api/assetRegistryApi';
 import { commonApi } from '@/api/commonApi';
 import { queryOptions } from '@/api/queryOptions';
@@ -29,7 +36,10 @@ export default function AssetRegistryPage() {
   const [sortOption, setSortOption] = useState<AssetSortOption>('date-desc');
   const [currentPage, setCurrentPage] = useState(1);
   const [addOpen, setAddOpen] = useState(false);
+  const [addMultipleOpen, setAddMultipleOpen] = useState(false);
+  const [uploadFile, setUploadFile] = useState<File | null>(null);
   const [viewRecord, setViewRecord] = useState<AssetRecord | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const { data: choices = {} } = useQuery({
     queryKey: ['common-choices'],
@@ -192,15 +202,42 @@ export default function AssetRegistryPage() {
             </Button>
           </div>
 
-          <Button
-            size="sm"
-            variant="success"
-            leftIcon={<Plus className="h-3.5 w-3.5" />}
-            onClick={() => setAddOpen(true)}
-            className="h-7 rounded-none px-3 text-[12px] font-bold"
-          >
-            Add Single
-          </Button>
+          <div className="flex gap-1">
+            <Button
+              size="sm"
+              variant="success"
+              leftIcon={<Plus className="h-3.5 w-3.5" />}
+              onClick={() => setAddOpen(true)}
+              className="h-7 rounded-none px-3 text-[12px] font-bold"
+            >
+              Add Single
+            </Button>
+            <Button
+              size="sm"
+              variant="secondary"
+              leftIcon={<Layers className="h-3.5 w-3.5" />}
+              onClick={() => fileInputRef.current?.click()}
+              className="h-7 rounded-none px-3 text-[12px] font-bold"
+            >
+              Add Multiple
+            </Button>
+            {/* Hidden file input — CSV / Excel only */}
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".csv,.xlsx,.xls,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-excel,text/csv"
+              className="hidden"
+              onChange={(e) => {
+                const file = e.target.files?.[0] ?? null;
+                if (file) {
+                  setUploadFile(file);
+                  setAddMultipleOpen(true);
+                }
+                // reset so the same file can be re-selected if needed
+                e.target.value = '';
+              }}
+            />
+          </div>
         </div>
 
         <div className="shrink-0 bg-[#7f7a7b] px-3 py-1 text-center text-[14px] font-bold uppercase text-white">
@@ -232,7 +269,7 @@ export default function AssetRegistryPage() {
                     </button>
                   </th>
                   <th className="px-2 py-2 font-bold text-black">
-                    Regist. No.
+                    Registor. No.
                   </th>
                   <th className="px-2 py-2 font-bold text-black">
                     <button
@@ -253,12 +290,14 @@ export default function AssetRegistryPage() {
                     </button>
                   </th>
                   <th className="px-2 py-2 font-bold text-black">
-                    Description
+                    Asset Description
                   </th>
-                  <th className="px-2 py-2 font-bold text-black">Reg/Serial</th>
+                  <th className="px-2 py-2 font-bold text-black">
+                    Reg/Serial Number
+                  </th>
                   <th className="px-2 py-2 font-bold text-black">Currency</th>
                   <th className="px-2 py-2 font-bold text-black text-right">
-                    Est. Value
+                    Estimate Value
                   </th>
                   <th className="px-2 py-2 font-bold text-black">
                     Sub. Start Date
@@ -354,6 +393,45 @@ export default function AssetRegistryPage() {
           }}
           onCancel={() => setAddOpen(false)}
         />
+      </Modal>
+
+      <Modal
+        open={addMultipleOpen}
+        onClose={() => {
+          setAddMultipleOpen(false);
+          setUploadFile(null);
+        }}
+        title="Upload Multiple Records"
+        size="sm"
+      >
+        <div className="flex flex-col gap-4 p-6">
+          <div className="flex items-center gap-3 rounded border border-slate-200 bg-slate-50 px-4 py-3">
+            <Layers className="h-5 w-5 shrink-0 text-slate-400" />
+            <div className="min-w-0">
+              <p className="truncate text-sm font-medium text-slate-800">
+                {uploadFile?.name}
+              </p>
+              <p className="text-xs text-slate-500">
+                {uploadFile ? (uploadFile.size / 1024).toFixed(1) + ' KB' : ''}
+              </p>
+            </div>
+          </div>
+          <p className="text-sm text-slate-500">
+            Import functionality coming soon. Your file has been selected and is
+            ready for processing.
+          </p>
+          <div className="flex justify-end gap-2">
+            <Button
+              variant="ghost"
+              onClick={() => {
+                setAddMultipleOpen(false);
+                setUploadFile(null);
+              }}
+            >
+              Close
+            </Button>
+          </div>
+        </div>
       </Modal>
 
       {viewRecord && (

--- a/frontend/src/pages/AssetRegistryPage.tsx
+++ b/frontend/src/pages/AssetRegistryPage.tsx
@@ -260,15 +260,18 @@ export default function AssetRegistryPage() {
                   <th className="px-2 py-2 font-bold text-black text-right">
                     Est. Value
                   </th>
-                  <th className="px-2 py-2 font-bold text-black">Sub. Start</th>
-                  <th className="px-2 py-2 font-bold text-black">Sub. End</th>
-                  <th className="px-2 py-2 font-bold text-black">Status</th>
+                  <th className="px-2 py-2 font-bold text-black">
+                    Sub. Start Date
+                  </th>
+                  <th className="px-2 py-2 font-bold text-black">
+                    Sub. End Date
+                  </th>
                   <th className="px-2 py-2 font-bold text-black" />
                 </tr>
               </thead>
               <tbody>
                 {isLoading ? (
-                  <TableSkeleton rows={8} cols={12} />
+                  <TableSkeleton rows={8} cols={11} />
                 ) : !sortedRecords.length ? (
                   <EmptyState message="No assets found." />
                 ) : (
@@ -309,18 +312,6 @@ export default function AssetRegistryPage() {
                       </td>
                       <td className="border-r border-[#8f8f8f] px-2 py-2">
                         {formatDate(rec.subscription_end_date)}
-                      </td>
-                      <td className="border-r border-[#8f8f8f] px-2 py-2">
-                        <span
-                          className={cn(
-                            'inline-block rounded px-1.5 py-0.5 text-[11px] font-semibold uppercase',
-                            rec.status === 'active'
-                              ? 'bg-green-100 text-green-800'
-                              : 'bg-red-100 text-red-700',
-                          )}
-                        >
-                          {rec.status}
-                        </span>
                       </td>
                       <td className="px-2 py-2">
                         <button

--- a/frontend/src/pages/CollateralPage.tsx
+++ b/frontend/src/pages/CollateralPage.tsx
@@ -5,6 +5,7 @@ import {
   ArrowDown,
   ArrowUp,
   ArrowUpDown,
+  Eye,
   Layers,
   Plus,
   Search,
@@ -18,7 +19,12 @@ import { Modal } from '@/components/shared/Modal';
 import { CollateralForm } from '@/components/collateral/CollateralForm';
 import { CollateralViewModal } from '@/components/collateral/CollateralViewModal';
 import { NumberedPaginationFooter } from '@/components/shared/NumberedPaginationFooter';
-import { cn, formatCurrency, formatDate, formatDollarAmount } from '@/lib/utils';
+import {
+  cn,
+  formatCurrency,
+  formatDate,
+  formatDollarAmount,
+} from '@/lib/utils';
 import { invalidateRegistryQueries } from '@/lib/registryCache';
 import { registryQueryOptions } from '@/lib/registryQueryOptions';
 import { useAuthStore } from '@/store';
@@ -28,14 +34,51 @@ const PAGE_SIZE = 20;
 
 type CollateralSortOption = 'date-desc' | 'date-asc' | 'name-asc' | 'name-desc';
 
+type CollateralSearchField = 'agreement_number' | 'debtor' | 'reg_serial_number';
+
+const SEARCH_FIELD_OPTIONS: { value: CollateralSearchField; label: string }[] = [
+  { value: 'agreement_number', label: 'Agreement Number' },
+  { value: 'debtor', label: 'Debtor' },
+  { value: 'reg_serial_number', label: 'Reg/Serial Number' },
+];
+
+const SEARCH_FIELD_PLACEHOLDERS: Record<CollateralSearchField, string> = {
+  agreement_number: 'Search by agreement number...',
+  debtor: 'Search by debtor...',
+  reg_serial_number: 'Search by reg/serial number...',
+};
+
+/** Agreement end date has passed (matches backend pending-discharge logic). */
+function isExpired(rec: CollateralRecord): boolean {
+  if (!rec.end_date) {
+    return false;
+  }
+  const end = new Date(rec.end_date);
+  if (Number.isNaN(end.getTime())) {
+    return false;
+  }
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  return end < today;
+}
+
+/** True when a loan's end date has passed and it has not yet been discharged. */
+function isPendingDischarge(rec: CollateralRecord): boolean {
+  return isExpired(rec) && rec.status !== 'discharged';
+}
+
 export default function CollateralPage() {
   const queryClient = useQueryClient();
   const authReady = useAuthStore((s) => s.authReady);
+  const [searchField, setSearchField] =
+    useState<CollateralSearchField>('agreement_number');
   const [searchValue, setSearchValue] = useState('');
   const [sortOption, setSortOption] =
     useState<CollateralSortOption>('date-desc');
   const [currentPage, setCurrentPage] = useState(1);
   const [appliedSearch, setAppliedSearch] = useState('');
+  const [appliedSearchField, setAppliedSearchField] =
+    useState<CollateralSearchField>('agreement_number');
   const [addOpen, setAddOpen] = useState(false);
   const [addMultipleOpen, setAddMultipleOpen] = useState(false);
   const [uploadFile, setUploadFile] = useState<File | null>(null);
@@ -55,10 +98,17 @@ export default function CollateralPage() {
     isError,
     isFetching,
   } = useQuery({
-    queryKey: ['collateral-records', appliedSearch, currentPage],
+    queryKey: [
+      'collateral-records',
+      appliedSearch,
+      appliedSearchField,
+      currentPage,
+    ],
     queryFn: () =>
       collateralApi.getRecords({
-        ...(appliedSearch ? { search: appliedSearch } : {}),
+        ...(appliedSearch
+          ? { search: appliedSearch, search_field: appliedSearchField }
+          : {}),
         page: currentPage,
         page_size: PAGE_SIZE,
       }),
@@ -70,6 +120,7 @@ export default function CollateralPage() {
 
   const handleSearch = () => {
     setAppliedSearch(searchValue.trim());
+    setAppliedSearchField(searchField);
     setCurrentPage(1);
   };
 
@@ -77,9 +128,20 @@ export default function CollateralPage() {
     if (clearFilters) {
       setSearchValue('');
       setAppliedSearch('');
+      setSearchField('agreement_number');
+      setAppliedSearchField('agreement_number');
     }
     setCurrentPage(1);
     invalidateRegistryQueries(queryClient, 'collateral');
+  };
+
+  const handleViewRecord = (rec: CollateralRecord) => {
+    void queryClient.prefetchQuery({
+      queryKey: ['collateral-detail', rec.id],
+      queryFn: () => collateralApi.getRecord(rec.id),
+      staleTime: 5 * 60 * 1000,
+    });
+    setViewRecord(rec);
   };
 
   const totalRecords = recordsData?.count ?? 0;
@@ -160,11 +222,24 @@ export default function CollateralPage() {
         <div className="flex flex-wrap items-center justify-between gap-2 border-b border-[#8f8f8f] px-3 py-2">
           <div className="flex flex-wrap items-center gap-2">
             <span className="text-[12px] font-bold text-black">Search</span>
+            <select
+              value={searchField}
+              onChange={(e) =>
+                setSearchField(e.target.value as CollateralSearchField)
+              }
+              className="h-7 min-w-[140px] rounded-none border border-black bg-white px-2 text-[12px]"
+            >
+              {SEARCH_FIELD_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
             <input
               value={searchValue}
               onChange={(e) => setSearchValue(e.target.value)}
               onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
-              placeholder="Agreement, debtor, reg..."
+              placeholder={SEARCH_FIELD_PLACEHOLDERS[searchField]}
               className="h-7 w-56 border border-black bg-white px-2 text-[12px] focus:outline-none"
             />
             <Button
@@ -176,6 +251,21 @@ export default function CollateralPage() {
             >
               Search
             </Button>
+            {appliedSearch ? (
+              <button
+                type="button"
+                className="text-[11px] text-[#196A86] underline"
+                onClick={() => {
+                  setSearchValue('');
+                  setAppliedSearch('');
+                  setSearchField('agreement_number');
+                  setAppliedSearchField('agreement_number');
+                  setCurrentPage(1);
+                }}
+              >
+                Clear filter
+              </button>
+            ) : null}
           </div>
 
           <div className="flex gap-1">
@@ -217,7 +307,7 @@ export default function CollateralPage() {
         </div>
 
         <div className="bg-[#7f7a7b] px-3 py-1 text-center text-[14px] font-bold uppercase text-white">
-          Active Debts
+          Active Agreements
         </div>
 
         <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
@@ -244,7 +334,7 @@ export default function CollateralPage() {
                       )}
                     </button>
                   </th>
-                  <th className="px-2 py-2 font-bold">Financier</th>
+                  <th className="px-2 py-2 font-bold">Agreement No.</th>
                   <th className="px-2 py-2 font-bold">
                     <button
                       type="button"
@@ -263,22 +353,23 @@ export default function CollateralPage() {
                       )}
                     </button>
                   </th>
-                  <th className="px-2 py-2 font-bold">Asset</th>
-                  <th className="px-2 py-2 font-bold">Reg/Serial</th>
+                  <th className="px-2 py-2 font-bold">Asset Description</th>
+                  <th className="px-2 py-2 font-bold">Reg/Serial Number</th>
                   <th className="px-2 py-2 font-bold">Currency</th>
-                  <th className="px-2 py-2 font-bold text-right">Loan</th>
-                  <th className="px-2 py-2 font-bold">Start</th>
-                  <th className="px-2 py-2 font-bold">End</th>
-                  <th className="px-2 py-2 font-bold">Status</th>
+                  <th className="px-2 py-2 font-bold text-right">
+                    Loan Amount
+                  </th>
+                  <th className="px-2 py-2 font-bold">Start Date</th>
+                  <th className="px-2 py-2 font-bold">End Date</th>
                   <th className="px-2 py-2 font-bold" />
                 </tr>
               </thead>
               <tbody>
                 {loadingRecords ? (
-                  <TableSkeleton rows={8} cols={12} />
+                  <TableSkeleton rows={8} cols={11} />
                 ) : isError ? (
                   <tr>
-                    <td colSpan={12} className="py-6 text-center text-red-500">
+                    <td colSpan={11} className="py-6 text-center text-red-500">
                       Failed to load records.
                     </td>
                   </tr>
@@ -299,8 +390,8 @@ export default function CollateralPage() {
                       <td className="border-r border-[#8f8f8f] px-2 py-2">
                         {formatDate(rec.lodge_date)}
                       </td>
-                      <td className="border-r border-[#8f8f8f] px-2 py-2 font-bold text-[#196A86]">
-                        {rec.financier_name}
+                      <td className="border-r border-[#8f8f8f] px-2 py-2">
+                        {rec.agreement_number}
                       </td>
                       <td className="border-r border-[#8f8f8f] px-2 py-2">
                         {rec.debtor_name}
@@ -323,28 +414,18 @@ export default function CollateralPage() {
                       <td className="border-r border-[#8f8f8f] px-2 py-2">
                         {formatDate(rec.end_date)}
                       </td>
-                      <td className="border-r border-[#8f8f8f] px-2 py-2">
-                        <span
-                          className={cn(
-                            'inline-block rounded px-1.5 py-0.5 text-[11px] font-semibold uppercase',
-                            rec.status === 'active'
-                              ? 'bg-green-100 text-green-800'
-                              : rec.status === 'pending_discharge'
-                                ? 'bg-amber-100 text-amber-800'
-                                : 'bg-slate-100 text-slate-600',
-                          )}
-                        >
-                          {rec.status === 'pending_discharge'
-                            ? 'Pending'
-                            : rec.status}
-                        </span>
-                      </td>
                       <td className="px-2 py-2">
                         <button
                           type="button"
-                          onClick={() => setViewRecord(rec)}
-                          className="bg-[#196A86] px-2 py-1 text-[11px] font-bold text-white hover:bg-[#15586f]"
+                          onClick={() => handleViewRecord(rec)}
+                          className={cn(
+                            'flex items-center gap-1 px-2 py-1 text-[11px] font-bold uppercase text-white',
+                            isPendingDischarge(rec)
+                              ? 'bg-[#f97316] hover:bg-[#ea580c]'
+                              : 'bg-[#196A86] hover:bg-[#15586f]',
+                          )}
                         >
+                          <Eye className="h-3 w-3" />
                           View
                         </button>
                       </td>
@@ -426,10 +507,6 @@ export default function CollateralPage() {
           record={viewRecord}
           onClose={() => setViewRecord(null)}
           onSaved={() => {
-            setViewRecord(null);
-            refreshList(false);
-          }}
-          onDeleted={() => {
             setViewRecord(null);
             refreshList(false);
           }}

--- a/frontend/src/pages/CollateralPage.tsx
+++ b/frontend/src/pages/CollateralPage.tsx
@@ -1,7 +1,14 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
-import { ArrowDown, ArrowUp, ArrowUpDown, Plus, Search } from 'lucide-react';
+import {
+  ArrowDown,
+  ArrowUp,
+  ArrowUpDown,
+  Layers,
+  Plus,
+  Search,
+} from 'lucide-react';
 import { collateralApi } from '@/api/collateralApi';
 import { InlineStat } from '@/components/shared/InlineStat';
 import { TableSkeleton } from '@/components/shared/TableSkeleton';
@@ -11,7 +18,7 @@ import { Modal } from '@/components/shared/Modal';
 import { CollateralForm } from '@/components/collateral/CollateralForm';
 import { CollateralViewModal } from '@/components/collateral/CollateralViewModal';
 import { NumberedPaginationFooter } from '@/components/shared/NumberedPaginationFooter';
-import { cn, formatCurrency, formatDate } from '@/lib/utils';
+import { cn, formatCurrency, formatDate, formatDollarAmount } from '@/lib/utils';
 import { invalidateRegistryQueries } from '@/lib/registryCache';
 import { registryQueryOptions } from '@/lib/registryQueryOptions';
 import { useAuthStore } from '@/store';
@@ -30,6 +37,9 @@ export default function CollateralPage() {
   const [currentPage, setCurrentPage] = useState(1);
   const [appliedSearch, setAppliedSearch] = useState('');
   const [addOpen, setAddOpen] = useState(false);
+  const [addMultipleOpen, setAddMultipleOpen] = useState(false);
+  const [uploadFile, setUploadFile] = useState<File | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const [viewRecord, setViewRecord] = useState<CollateralRecord | null>(null);
 
   const { data: statsData } = useQuery({
@@ -140,6 +150,11 @@ export default function CollateralPage() {
             label="Pending Discharge"
             value={statsData?.pending_discharge_confirmation ?? 0}
           />
+          <InlineStat
+            label="Active Loan Value"
+            value={formatDollarAmount(statsData?.total_active_loan_value ?? 0)}
+            valueClassName="text-xl"
+          />
         </div>
 
         <div className="flex flex-wrap items-center justify-between gap-2 border-b border-[#8f8f8f] px-3 py-2">
@@ -163,15 +178,42 @@ export default function CollateralPage() {
             </Button>
           </div>
 
-          <Button
-            size="sm"
-            variant="success"
-            leftIcon={<Plus className="h-3.5 w-3.5" />}
-            onClick={() => setAddOpen(true)}
-            className="h-7 rounded-none px-3 text-[12px] font-bold"
-          >
-            Add Single
-          </Button>
+          <div className="flex gap-1">
+            <Button
+              size="sm"
+              variant="success"
+              leftIcon={<Plus className="h-3.5 w-3.5" />}
+              onClick={() => setAddOpen(true)}
+              className="h-7 rounded-none px-3 text-[12px] font-bold"
+            >
+              Add Single
+            </Button>
+            <Button
+              size="sm"
+              variant="secondary"
+              leftIcon={<Layers className="h-3.5 w-3.5" />}
+              onClick={() => fileInputRef.current?.click()}
+              className="h-7 rounded-none px-3 text-[12px] font-bold"
+            >
+              Add Multiple
+            </Button>
+            {/* Hidden file input — CSV / Excel only */}
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".csv,.xlsx,.xls,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-excel,text/csv"
+              className="hidden"
+              onChange={(e) => {
+                const file = e.target.files?.[0] ?? null;
+                if (file) {
+                  setUploadFile(file);
+                  setAddMultipleOpen(true);
+                }
+                // reset so the same file can be re-selected if needed
+                e.target.value = '';
+              }}
+            />
+          </div>
         </div>
 
         <div className="bg-[#7f7a7b] px-3 py-1 text-center text-[14px] font-bold uppercase text-white">
@@ -202,7 +244,7 @@ export default function CollateralPage() {
                       )}
                     </button>
                   </th>
-                  <th className="px-2 py-2 font-bold">Agreement No.</th>
+                  <th className="px-2 py-2 font-bold">Financier</th>
                   <th className="px-2 py-2 font-bold">
                     <button
                       type="button"
@@ -258,7 +300,7 @@ export default function CollateralPage() {
                         {formatDate(rec.lodge_date)}
                       </td>
                       <td className="border-r border-[#8f8f8f] px-2 py-2 font-bold text-[#196A86]">
-                        {rec.agreement_number}
+                        {rec.financier_name}
                       </td>
                       <td className="border-r border-[#8f8f8f] px-2 py-2">
                         {rec.debtor_name}
@@ -338,6 +380,45 @@ export default function CollateralPage() {
           }}
           onCancel={() => setAddOpen(false)}
         />
+      </Modal>
+
+      <Modal
+        open={addMultipleOpen}
+        onClose={() => {
+          setAddMultipleOpen(false);
+          setUploadFile(null);
+        }}
+        title="Upload Multiple Records"
+        size="sm"
+      >
+        <div className="flex flex-col gap-4 p-6">
+          <div className="flex items-center gap-3 rounded border border-slate-200 bg-slate-50 px-4 py-3">
+            <Layers className="h-5 w-5 shrink-0 text-slate-400" />
+            <div className="min-w-0">
+              <p className="truncate text-sm font-medium text-slate-800">
+                {uploadFile?.name}
+              </p>
+              <p className="text-xs text-slate-500">
+                {uploadFile ? (uploadFile.size / 1024).toFixed(1) + ' KB' : ''}
+              </p>
+            </div>
+          </div>
+          <p className="text-sm text-slate-500">
+            Import functionality coming soon. Your file has been selected and is
+            ready for processing.
+          </p>
+          <div className="flex justify-end gap-2">
+            <Button
+              variant="ghost"
+              onClick={() => {
+                setAddMultipleOpen(false);
+                setUploadFile(null);
+              }}
+            >
+              Close
+            </Button>
+          </div>
+        </div>
       </Modal>
 
       {viewRecord && (

--- a/frontend/src/pages/HirePurchasePage.tsx
+++ b/frontend/src/pages/HirePurchasePage.tsx
@@ -1,17 +1,16 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import {
   ArrowDown,
   ArrowUp,
   ArrowUpDown,
-  Building2,
   Eye,
+  Layers,
   Plus,
   Search,
 } from 'lucide-react';
 import { hirePurchaseApi } from '@/api/hirePurchaseApi';
-import { clientsApi } from '@/api/clientsApi';
 import { InlineStat } from '@/components/shared/InlineStat';
 import { TableSkeleton } from '@/components/shared/TableSkeleton';
 import { EmptyState } from '@/components/shared/EmptyState';
@@ -32,71 +31,57 @@ type HirePurchaseSortOption =
   | 'name-asc'
   | 'name-desc';
 
+/** Agreement end date has passed (matches backend pending-closure logic). */
+function isExpired(rec: HirePurchaseRecord): boolean {
+  if (!rec.end_date) {
+    return false;
+  }
+  const end = new Date(rec.end_date);
+  if (Number.isNaN(end.getTime())) {
+    return false;
+  }
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  return end < today;
+}
+
 export default function HirePurchasePage() {
   const queryClient = useQueryClient();
-  const [financierQuery, setFinancierQuery] = useState('');
-  const [selectedFinancier, setSelectedFinancier] = useState('');
-  const [selectedFinancierLabel, setSelectedFinancierLabel] = useState('');
+  const [searchValue, setSearchValue] = useState('');
+  const [appliedSearch, setAppliedSearch] = useState('');
   const [sortOption, setSortOption] =
     useState<HirePurchaseSortOption>('date-desc');
   const [currentPage, setCurrentPage] = useState(1);
   const [addOpen, setAddOpen] = useState(false);
+  const [addMultipleOpen, setAddMultipleOpen] = useState(false);
+  const [uploadFile, setUploadFile] = useState<File | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const [viewRecord, setViewRecord] = useState<HirePurchaseRecord | null>(null);
 
   const { data: statsData } = useQuery({
-    queryKey: ['hp-dashboard', selectedFinancier],
-    queryFn: () =>
-      hirePurchaseApi.getDashboard(
-        selectedFinancier
-          ? { financier_id: Number(selectedFinancier) }
-          : undefined,
-      ),
+    queryKey: ['hp-dashboard'],
+    queryFn: () => hirePurchaseApi.getDashboard(),
   });
 
   const { data: recordsData, isLoading } = useQuery({
-    queryKey: ['hp-records', selectedFinancier, currentPage],
+    queryKey: ['hp-records', appliedSearch, currentPage],
     queryFn: () =>
       hirePurchaseApi.getRecords({
-        ...(selectedFinancier
-          ? { financier_id: Number(selectedFinancier) }
-          : {}),
+        ...(appliedSearch ? { search: appliedSearch } : {}),
         page: currentPage,
         page_size: PAGE_SIZE,
       }),
   });
 
-  const handleFinancierSearch = async () => {
-    const q = financierQuery.trim();
-    if (!q) {
-      setSelectedFinancier('');
-      setSelectedFinancierLabel('');
-      setCurrentPage(1);
-      return;
-    }
-    const results = await clientsApi.searchClients(q);
-    if (results.length === 1) {
-      const client = results[0];
-      setSelectedFinancier(String(client.id));
-      setSelectedFinancierLabel(client.name ?? String(client.id));
-      setCurrentPage(1);
-      return;
-    }
-    if (results.length > 1) {
-      const first = results[0];
-      setSelectedFinancier(String(first.id));
-      setSelectedFinancierLabel(first.name ?? '');
-      setCurrentPage(1);
-      toast.message(`Showing results for ${first.name ?? 'first match'}`);
-      return;
-    }
-    toast.error('No financier found');
+  const handleSearch = () => {
+    setAppliedSearch(searchValue.trim());
+    setCurrentPage(1);
   };
 
   const refreshList = (clearFilters = false) => {
     if (clearFilters) {
-      setFinancierQuery('');
-      setSelectedFinancier('');
-      setSelectedFinancierLabel('');
+      setSearchValue('');
+      setAppliedSearch('');
     }
     setCurrentPage(1);
     invalidateRegistryQueries(queryClient, 'hp');
@@ -200,33 +185,29 @@ export default function HirePurchasePage() {
         <div className="flex flex-wrap items-center justify-between gap-2 border-b border-[#8f8f8f] px-3 py-2">
           <div className="flex flex-wrap items-center gap-2">
             <span className="text-[12px] font-bold text-black">Search</span>
-            <Building2 className="h-3 w-3" />
             <input
-              value={financierQuery}
-              onChange={(e) => setFinancierQuery(e.target.value)}
-              onKeyDown={(e) =>
-                e.key === 'Enter' && void handleFinancierSearch()
-              }
-              placeholder={selectedFinancierLabel || 'Financier name...'}
-              className="h-7 w-52 border border-black bg-white px-2 text-[12px] focus:outline-none"
+              value={searchValue}
+              onChange={(e) => setSearchValue(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
+              placeholder="Agreement, purchaser, financier, reg..."
+              className="h-7 w-56 border border-black bg-white px-2 text-[12px] focus:outline-none"
             />
             <Button
               size="sm"
               variant="primary"
               leftIcon={<Search className="h-3 w-3" />}
-              onClick={() => void handleFinancierSearch()}
+              onClick={handleSearch}
               className="h-7 px-2 text-[12px]"
             >
               Search
             </Button>
-            {selectedFinancier ? (
+            {appliedSearch ? (
               <button
                 type="button"
                 className="text-[11px] text-[#196A86] underline"
                 onClick={() => {
-                  setSelectedFinancier('');
-                  setSelectedFinancierLabel('');
-                  setFinancierQuery('');
+                  setSearchValue('');
+                  setAppliedSearch('');
                   setCurrentPage(1);
                 }}
               >
@@ -235,15 +216,42 @@ export default function HirePurchasePage() {
             ) : null}
           </div>
 
-          <Button
-            size="sm"
-            variant="success"
-            leftIcon={<Plus className="h-3.5 w-3.5" />}
-            onClick={() => setAddOpen(true)}
-            className="h-7 rounded-none px-3 text-[12px] font-bold"
-          >
-            Add Single
-          </Button>
+          <div className="flex gap-1">
+            <Button
+              size="sm"
+              variant="success"
+              leftIcon={<Plus className="h-3.5 w-3.5" />}
+              onClick={() => setAddOpen(true)}
+              className="h-7 rounded-none px-3 text-[12px] font-bold"
+            >
+              Add Single
+            </Button>
+            <Button
+              size="sm"
+              variant="secondary"
+              leftIcon={<Layers className="h-3.5 w-3.5" />}
+              onClick={() => fileInputRef.current?.click()}
+              className="h-7 rounded-none px-3 text-[12px] font-bold"
+            >
+              Add Multiple
+            </Button>
+            {/* Hidden file input — CSV / Excel only */}
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".csv,.xlsx,.xls,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-excel,text/csv"
+              className="hidden"
+              onChange={(e) => {
+                const file = e.target.files?.[0] ?? null;
+                if (file) {
+                  setUploadFile(file);
+                  setAddMultipleOpen(true);
+                }
+                // reset so the same file can be re-selected if needed
+                e.target.value = '';
+              }}
+            />
+          </div>
         </div>
 
         <div className="bg-[#7f7a7b] px-3 py-1 text-center text-[14px] font-bold uppercase text-white">
@@ -299,13 +307,12 @@ export default function HirePurchasePage() {
                   <th className="px-2 py-2 font-bold text-right">Amount</th>
                   <th className="px-2 py-2 font-bold">Start</th>
                   <th className="px-2 py-2 font-bold">End</th>
-                  <th className="px-2 py-2 font-bold">Status</th>
                   <th className="px-2 py-2 font-bold" />
                 </tr>
               </thead>
               <tbody>
                 {isLoading ? (
-                  <TableSkeleton rows={8} cols={12} />
+                  <TableSkeleton rows={8} cols={11} />
                 ) : !sortedRecords.length ? (
                   <EmptyState message="No hire purchase agreements found." />
                 ) : (
@@ -347,27 +354,16 @@ export default function HirePurchasePage() {
                       <td className="border-r border-[#8f8f8f] px-2 py-2">
                         {formatDate(rec.end_date)}
                       </td>
-                      <td className="border-r border-[#8f8f8f] px-2 py-2">
-                        <span
-                          className={cn(
-                            'inline-block rounded px-1.5 py-0.5 text-[11px] font-semibold uppercase',
-                            rec.status === 'active'
-                              ? 'bg-green-100 text-green-800'
-                              : rec.status === 'pending_closure'
-                                ? 'bg-amber-100 text-amber-800'
-                                : 'bg-slate-100 text-slate-600',
-                          )}
-                        >
-                          {rec.status === 'pending_closure'
-                            ? 'Pending'
-                            : rec.status}
-                        </span>
-                      </td>
                       <td className="px-2 py-2">
                         <button
                           type="button"
                           onClick={() => setViewRecord(rec)}
-                          className="flex items-center gap-1 bg-[#196A86] px-2 py-1 text-[11px] font-bold text-white hover:bg-[#15586f]"
+                          className={cn(
+                            'flex items-center gap-1 px-2 py-1 text-[11px] font-bold uppercase text-white',
+                            isExpired(rec)
+                              ? 'bg-[#f97316] hover:bg-[#ea580c]'
+                              : 'bg-[#196A86] hover:bg-[#15586f]',
+                          )}
                         >
                           <Eye className="h-3 w-3" />
                           View
@@ -405,6 +401,45 @@ export default function HirePurchasePage() {
           }}
           onCancel={() => setAddOpen(false)}
         />
+      </Modal>
+
+      <Modal
+        open={addMultipleOpen}
+        onClose={() => {
+          setAddMultipleOpen(false);
+          setUploadFile(null);
+        }}
+        title="Upload Multiple Records"
+        size="sm"
+      >
+        <div className="flex flex-col gap-4 p-6">
+          <div className="flex items-center gap-3 rounded border border-slate-200 bg-slate-50 px-4 py-3">
+            <Layers className="h-5 w-5 shrink-0 text-slate-400" />
+            <div className="min-w-0">
+              <p className="truncate text-sm font-medium text-slate-800">
+                {uploadFile?.name}
+              </p>
+              <p className="text-xs text-slate-500">
+                {uploadFile ? (uploadFile.size / 1024).toFixed(1) + ' KB' : ''}
+              </p>
+            </div>
+          </div>
+          <p className="text-sm text-slate-500">
+            Import functionality coming soon. Your file has been selected and is
+            ready for processing.
+          </p>
+          <div className="flex justify-end gap-2">
+            <Button
+              variant="ghost"
+              onClick={() => {
+                setAddMultipleOpen(false);
+                setUploadFile(null);
+              }}
+            >
+              Close
+            </Button>
+          </div>
+        </div>
       </Modal>
 
       {viewRecord && (

--- a/frontend/src/pages/HirePurchasePage.tsx
+++ b/frontend/src/pages/HirePurchasePage.tsx
@@ -21,6 +21,8 @@ import { HirePurchaseViewModal } from '@/components/hire-purchase/HirePurchaseVi
 import { NumberedPaginationFooter } from '@/components/shared/NumberedPaginationFooter';
 import { cn, formatCurrency, formatDate } from '@/lib/utils';
 import { invalidateRegistryQueries } from '@/lib/registryCache';
+import { registryQueryOptions } from '@/lib/registryQueryOptions';
+import { useAuthStore } from '@/store';
 import type { HirePurchaseRecord } from '@/types';
 
 const PAGE_SIZE = 20;
@@ -30,6 +32,20 @@ type HirePurchaseSortOption =
   | 'date-asc'
   | 'name-asc'
   | 'name-desc';
+
+type HirePurchaseSearchField = 'agreement_number' | 'purchaser' | 'reg_serial_number';
+
+const SEARCH_FIELD_OPTIONS: { value: HirePurchaseSearchField; label: string }[] = [
+  { value: 'agreement_number', label: 'Agreement Number' },
+  { value: 'purchaser', label: 'Purchaser Name' },
+  { value: 'reg_serial_number', label: 'Reg/Serial Number' },
+];
+
+const SEARCH_FIELD_PLACEHOLDERS: Record<HirePurchaseSearchField, string> = {
+  agreement_number: 'Search by agreement number...',
+  purchaser: 'Search by purchaser name...',
+  reg_serial_number: 'Search by reg/serial number...',
+};
 
 /** Agreement end date has passed (matches backend pending-closure logic). */
 function isExpired(rec: HirePurchaseRecord): boolean {
@@ -47,8 +63,13 @@ function isExpired(rec: HirePurchaseRecord): boolean {
 
 export default function HirePurchasePage() {
   const queryClient = useQueryClient();
+  const authReady = useAuthStore((s) => s.authReady);
+  const [searchField, setSearchField] =
+    useState<HirePurchaseSearchField>('agreement_number');
   const [searchValue, setSearchValue] = useState('');
   const [appliedSearch, setAppliedSearch] = useState('');
+  const [appliedSearchField, setAppliedSearchField] =
+    useState<HirePurchaseSearchField>('agreement_number');
   const [sortOption, setSortOption] =
     useState<HirePurchaseSortOption>('date-desc');
   const [currentPage, setCurrentPage] = useState(1);
@@ -61,20 +82,42 @@ export default function HirePurchasePage() {
   const { data: statsData } = useQuery({
     queryKey: ['hp-dashboard'],
     queryFn: () => hirePurchaseApi.getDashboard(),
+    enabled: authReady,
+    ...registryQueryOptions,
   });
 
-  const { data: recordsData, isLoading } = useQuery({
-    queryKey: ['hp-records', appliedSearch, currentPage],
+  const {
+    data: recordsData,
+    isLoading,
+    isFetching,
+  } = useQuery({
+    queryKey: ['hp-records', appliedSearch, appliedSearchField, currentPage],
     queryFn: () =>
       hirePurchaseApi.getRecords({
-        ...(appliedSearch ? { search: appliedSearch } : {}),
+        ...(appliedSearch
+          ? { search: appliedSearch, search_field: appliedSearchField }
+          : {}),
         page: currentPage,
         page_size: PAGE_SIZE,
       }),
+    enabled: authReady,
+    ...registryQueryOptions,
   });
+
+  const loadingRecords = !authReady || isLoading || isFetching;
+
+  const handleViewRecord = (rec: HirePurchaseRecord) => {
+    void queryClient.prefetchQuery({
+      queryKey: ['hire-purchase-detail', rec.id],
+      queryFn: () => hirePurchaseApi.getRecord(rec.id),
+      staleTime: 5 * 60 * 1000,
+    });
+    setViewRecord(rec);
+  };
 
   const handleSearch = () => {
     setAppliedSearch(searchValue.trim());
+    setAppliedSearchField(searchField);
     setCurrentPage(1);
   };
 
@@ -82,6 +125,8 @@ export default function HirePurchasePage() {
     if (clearFilters) {
       setSearchValue('');
       setAppliedSearch('');
+      setSearchField('agreement_number');
+      setAppliedSearchField('agreement_number');
     }
     setCurrentPage(1);
     invalidateRegistryQueries(queryClient, 'hp');
@@ -185,11 +230,24 @@ export default function HirePurchasePage() {
         <div className="flex flex-wrap items-center justify-between gap-2 border-b border-[#8f8f8f] px-3 py-2">
           <div className="flex flex-wrap items-center gap-2">
             <span className="text-[12px] font-bold text-black">Search</span>
+            <select
+              value={searchField}
+              onChange={(e) =>
+                setSearchField(e.target.value as HirePurchaseSearchField)
+              }
+              className="h-7 min-w-[140px] rounded-none border border-black bg-white px-2 text-[12px]"
+            >
+              {SEARCH_FIELD_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
             <input
               value={searchValue}
               onChange={(e) => setSearchValue(e.target.value)}
               onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
-              placeholder="Agreement, purchaser, financier, reg..."
+              placeholder={SEARCH_FIELD_PLACEHOLDERS[searchField]}
               className="h-7 w-56 border border-black bg-white px-2 text-[12px] focus:outline-none"
             />
             <Button
@@ -208,6 +266,8 @@ export default function HirePurchasePage() {
                 onClick={() => {
                   setSearchValue('');
                   setAppliedSearch('');
+                  setSearchField('agreement_number');
+                  setAppliedSearchField('agreement_number');
                   setCurrentPage(1);
                 }}
               >
@@ -311,7 +371,7 @@ export default function HirePurchasePage() {
                 </tr>
               </thead>
               <tbody>
-                {isLoading ? (
+                {loadingRecords ? (
                   <TableSkeleton rows={8} cols={11} />
                 ) : !sortedRecords.length ? (
                   <EmptyState message="No hire purchase agreements found." />
@@ -337,7 +397,7 @@ export default function HirePurchasePage() {
                         {rec.purchaser_name}
                       </td>
                       <td className="border-r border-[#8f8f8f] px-2 py-2">
-                        {rec.asset_make} {rec.asset_model}
+                        {rec.asset_description}
                       </td>
                       <td className="border-r border-[#8f8f8f] px-2 py-2">
                         {rec.reg_serial_number}
@@ -357,7 +417,7 @@ export default function HirePurchasePage() {
                       <td className="px-2 py-2">
                         <button
                           type="button"
-                          onClick={() => setViewRecord(rec)}
+                          onClick={() => handleViewRecord(rec)}
                           className={cn(
                             'flex items-center gap-1 px-2 py-1 text-[11px] font-bold uppercase text-white',
                             isExpired(rec)
@@ -447,10 +507,6 @@ export default function HirePurchasePage() {
           record={viewRecord}
           onClose={() => setViewRecord(null)}
           onSaved={() => {
-            setViewRecord(null);
-            refreshList(false);
-          }}
-          onDeleted={() => {
             setViewRecord(null);
             refreshList(false);
           }}

--- a/frontend/src/pages/ReportsPage.tsx
+++ b/frontend/src/pages/ReportsPage.tsx
@@ -1,0 +1,23 @@
+import { BarChart3 } from 'lucide-react';
+
+export default function ReportsPage() {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-4">
+      <div>
+        <h1 className="text-xl font-bold text-slate-900">Reports</h1>
+        <p className="text-sm text-slate-600">
+          Registry analytics and export tools.
+        </p>
+      </div>
+
+      <div className="flex flex-1 flex-col items-center justify-center rounded border border-dashed border-[#8f8f8f] bg-[#f7f5f1] px-6 py-16 text-center">
+        <BarChart3 className="mb-4 h-12 w-12 text-slate-400" />
+        <h2 className="text-lg font-semibold text-slate-800">Coming soon</h2>
+        <p className="mt-2 max-w-md text-sm text-slate-600">
+          Report dashboards and downloads are not available yet. Check back here
+          for collateral, hire purchase, and asset registry summaries.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/UsersManagementPage.tsx
+++ b/frontend/src/pages/UsersManagementPage.tsx
@@ -1,16 +1,33 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { Plus } from 'lucide-react';
+import { Building2, Plus } from 'lucide-react';
 import { toast } from 'sonner';
 import { usersApi, type CreateUserPayload } from '@/api/usersApi';
+import { clientsApi } from '@/api/clientsApi';
 import { TableSkeleton } from '@/components/shared/TableSkeleton';
 import { EmptyState } from '@/components/shared/EmptyState';
 import { NumberedPaginationFooter } from '@/components/shared/NumberedPaginationFooter';
 import { Modal } from '@/components/shared/Modal';
 import { Button } from '@/components/ui/button';
+import AutocompleteInput from '@/components/shared/AutocompleteInput';
+import { ClientCreateForm } from '@/components/clients/ClientCreateForm';
 import { formatDate } from '@/lib/utils';
+import type { SearchOption } from '@/lib/searchResults';
 
 const PAGE_SIZE = 20;
+
+function initialFormState(): CreateUserPayload {
+  return {
+    email: '',
+    username: '',
+    password: '',
+    first_name: '',
+    last_name: '',
+    position: '',
+    is_staff: false,
+    is_superuser: false,
+  };
+}
 
 export default function UsersManagementPage() {
   const queryClient = useQueryClient();
@@ -18,16 +35,27 @@ export default function UsersManagementPage() {
   const [search, setSearch] = useState('');
   const [appliedSearch, setAppliedSearch] = useState('');
   const [createOpen, setCreateOpen] = useState(false);
-  const [form, setForm] = useState<CreateUserPayload>({
-    email: '',
-    username: '',
-    password: '',
-    first_name: '',
-    last_name: '',
-    is_staff: false,
-    is_superuser: false,
-  });
+  const [addClientOpen, setAddClientOpen] = useState(false);
+  const [form, setForm] = useState<CreateUserPayload>(initialFormState);
+  const [clientId, setClientId] = useState<number | undefined>();
+  const [clientLabel, setClientLabel] = useState('');
+  const [clientEntityType, setClientEntityType] = useState<
+    'individual' | 'company'
+  >('company');
   const [saving, setSaving] = useState(false);
+  const clientSearchResults = useRef<SearchOption[]>([]);
+
+  const resetCreateForm = () => {
+    setForm(initialFormState());
+    setClientId(undefined);
+    setClientLabel('');
+    setClientEntityType('company');
+  };
+
+  const closeCreateModal = () => {
+    setCreateOpen(false);
+    resetCreateForm();
+  };
 
   const { data, isLoading, isError } = useQuery({
     queryKey: ['managed-users', page, appliedSearch],
@@ -48,27 +76,33 @@ export default function UsersManagementPage() {
 
   const handleCreate = async (e: React.FormEvent) => {
     e.preventDefault();
+
+    if (!form.is_staff && !clientId) {
+      toast.error('Client users must be linked to a client.');
+      return;
+    }
+
     setSaving(true);
     try {
       await usersApi.create({
         ...form,
         email: form.email.trim().toLowerCase(),
-        username: form.username.trim() || form.email.split('@')[0],
+        username: form.username?.trim() || form.email.split('@')[0],
+        ...(clientId ? { client_id: clientId } : {}),
+        ...(form.position?.trim() ? { position: form.position.trim() } : {}),
       });
       toast.success('User created');
-      setCreateOpen(false);
-      setForm({
-        email: '',
-        username: '',
-        password: '',
-        first_name: '',
-        last_name: '',
-        is_staff: false,
-        is_superuser: false,
-      });
+      closeCreateModal();
       queryClient.invalidateQueries({ queryKey: ['managed-users'] });
-    } catch {
-      toast.error('Could not create user');
+    } catch (err: unknown) {
+      const detail = (
+        err as { response?: { data?: { detail?: string; email?: string[] } } }
+      )?.response?.data;
+      const message =
+        (typeof detail?.detail === 'string' && detail.detail) ||
+        (Array.isArray(detail?.email) && detail.email.join(' ')) ||
+        'Could not create user';
+      toast.error(message);
     } finally {
       setSaving(false);
     }
@@ -158,10 +192,11 @@ export default function UsersManagementPage() {
 
       <Modal
         open={createOpen}
-        onClose={() => setCreateOpen(false)}
+        onClose={closeCreateModal}
         title="Create user"
+        size="md"
       >
-        <form onSubmit={handleCreate} className="space-y-3">
+        <form onSubmit={handleCreate} className="space-y-4 p-1">
           {(
             [
               ['email', 'Email', 'email'],
@@ -169,6 +204,7 @@ export default function UsersManagementPage() {
               ['password', 'Password', 'password'],
               ['first_name', 'First name', 'text'],
               ['last_name', 'Last name', 'text'],
+              ['position', 'Position', 'text'],
             ] as const
           ).map(([key, label, type]) => (
             <div key={key}>
@@ -184,6 +220,88 @@ export default function UsersManagementPage() {
               />
             </div>
           ))}
+
+          <div className="rounded border border-slate-200 bg-slate-50 p-3 space-y-3">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <p className="text-sm font-semibold text-slate-800">
+                Client association
+              </p>
+              <Button
+                type="button"
+                size="sm"
+                variant="secondary"
+                leftIcon={<Building2 className="h-3.5 w-3.5" />}
+                onClick={() => setAddClientOpen(true)}
+              >
+                Add Client
+              </Button>
+            </div>
+
+            <div>
+              <label className="text-xs font-medium text-slate-600">
+                Client type
+              </label>
+              <select
+                value={clientEntityType}
+                onChange={(e) => {
+                  setClientEntityType(
+                    e.target.value as 'individual' | 'company',
+                  );
+                  setClientId(undefined);
+                  setClientLabel('');
+                }}
+                className="mt-1 h-8 w-full rounded border border-slate-300 bg-white px-2 text-sm focus:outline-none focus:border-[#0f7d8e]"
+              >
+                <option value="company">Company</option>
+                <option value="individual">Individual</option>
+              </select>
+            </div>
+
+            <AutocompleteInput
+              label="Link client"
+              placeholder="Search client by name..."
+              queryKey={`user-create-client-${clientEntityType}`}
+              displayLabel={clientLabel}
+              fetchFn={async (q) => {
+                const results = await clientsApi.searchClients(q, {
+                  entityType: clientEntityType,
+                });
+                clientSearchResults.current = results;
+                return results;
+              }}
+              value={clientId}
+              onChange={(id) => {
+                if (!id) {
+                  setClientId(undefined);
+                  setClientLabel('');
+                  return;
+                }
+                setClientId(Number(id));
+                const match = clientSearchResults.current.find((r) => r.id === id);
+                setClientLabel(match?.name ?? '');
+              }}
+            />
+
+            {clientId ? (
+              <button
+                type="button"
+                className="text-xs text-[#196A86] underline"
+                onClick={() => {
+                  setClientId(undefined);
+                  setClientLabel('');
+                }}
+              >
+                Clear linked client
+              </button>
+            ) : null}
+
+            <p className="text-xs text-slate-500">
+              {form.is_staff
+                ? 'Optional for staff. Link a client to create a client portal user; leave blank for internal staff only.'
+                : 'Required for non-staff users. Search an existing client or use Add Client to register one first.'}
+            </p>
+          </div>
+
           <label className="flex items-center gap-2 text-sm">
             <input
               type="checkbox"
@@ -204,12 +322,9 @@ export default function UsersManagementPage() {
             />
             Superuser (admin tools)
           </label>
-          <div className="flex justify-end gap-2 pt-2">
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => setCreateOpen(false)}
-            >
+
+          <div className="flex justify-end gap-2 border-t border-slate-200 pt-3">
+            <Button type="button" variant="outline" onClick={closeCreateModal}>
               Cancel
             </Button>
             <Button type="submit" disabled={saving}>
@@ -217,6 +332,24 @@ export default function UsersManagementPage() {
             </Button>
           </div>
         </form>
+      </Modal>
+
+      <Modal
+        open={addClientOpen}
+        onClose={() => setAddClientOpen(false)}
+        title="Add Client"
+        size="md"
+      >
+        <ClientCreateForm
+          initialEntityType={clientEntityType}
+          onCancel={() => setAddClientOpen(false)}
+          onSuccess={({ id, name }) => {
+            setClientId(id);
+            setClientLabel(name);
+            setAddClientOpen(false);
+            toast.success(`${name} linked — ready to assign to user`);
+          }}
+        />
       </Modal>
     </div>
   );

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -14,6 +14,7 @@ import AssetRegistryPage from '@/pages/AssetRegistryPage';
 import AccountSettingsPage from '@/pages/AccountSettingsPage';
 import AuditLogsPage from '@/pages/AuditLogsPage';
 import UsersManagementPage from '@/pages/UsersManagementPage';
+import ReportsPage from '@/pages/ReportsPage';
 
 export const router = createBrowserRouter([
   {
@@ -59,6 +60,7 @@ export const router = createBrowserRouter([
         ),
       },
       { path: 'settings', element: <AccountSettingsPage /> },
+      { path: 'reports', element: <ReportsPage /> },
       {
         path: 'admin/audit-logs',
         element: (

--- a/frontend/src/routes/preloadConfig.ts
+++ b/frontend/src/routes/preloadConfig.ts
@@ -35,28 +35,27 @@ export function preloadRouteData(
  */
 export const routePreloadConfigs = {
   collateral: {
-    queryKey: ['collateral-stats'],
+    queryKey: ['collateral-dashboard'],
     queryFn: async () => {
       // Import here to avoid circular deps
-      const { fetchCollateralStats } = await import('@/api/collateralApi');
-      return fetchCollateralStats();
+      const { collateralApi } = await import('@/api/collateralApi');
+      return collateralApi.getDashboard();
     },
   },
 
   hirePurchase: {
     queryKey: ['hp-dashboard'],
     queryFn: async () => {
-      const { fetchHPDashboard } = await import('@/api/hirePurchaseApi');
-      return fetchHPDashboard();
+      const { hirePurchaseApi } = await import('@/api/hirePurchaseApi');
+      return hirePurchaseApi.getDashboard();
     },
   },
 
   registry: {
-    queryKey: ['asset-registry-stats'],
+    queryKey: ['registry-dashboard'],
     queryFn: async () => {
-      const { fetchAssetRegistryStats } =
-        await import('@/api/assetRegistryApi');
-      return fetchAssetRegistryStats();
+      const { assetRegistryApi } = await import('@/api/assetRegistryApi');
+      return assetRegistryApi.getDashboard();
     },
   },
 };

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -114,6 +114,7 @@ export interface HirePurchaseRecord {
   purchaser_name: string;
   purchaser_type: OwnerType;
   purchaser_id: number;
+  asset_description: string;
   asset_make: string;
   asset_model: string;
   asset_type: string;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -134,6 +134,8 @@ export interface HirePurchaseRecord {
   financier_id: number;
   data_date: string;
   status: 'active' | 'pending_closure' | 'closed';
+  data_source_display?: string;
+  data_source_position?: string;
 }
 
 export interface HirePurchaseDashboard {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -68,11 +68,14 @@ export interface CollateralRecord {
   financier_id: number;
   data_date: string;
   status: 'active' | 'pending_discharge' | 'discharged';
+  data_source_display?: string;
+  data_source_position?: string;
 }
 
 export interface CollateralDashboard {
   active_agreements: number;
   pending_discharge_confirmation: number;
+  total_active_loan_value: number;
   records: CollateralRecord[];
 }
 


### PR DESCRIPTION
## Summary

- Align Collateral and Hire Purchase registry list/stats filtering with role-based client scoping, and exclude closed/discharged records from dashboard views
- Rework view/edit modals with app-styled confirmation dialogs, read-only fields in edit mode, and consistent Update/Close actions
- Fix several frontend regressions on Asset Registry and the sidebar profile menu (missing imports/refs, layout, stacking, logout styling)

## Backend

- Add shared `scope_registry_to_client_portfolio()` helper for consistent client-user filtering by financier
- Filter list endpoints to active records only (`is_discharged=False` for Collateral, `closure_confirmed=False` for HP)
- Add lean `HirePurchaseRegistrationListSerializer` for dashboard/list responses
- Ensure stats endpoints use the same scoping logic as list endpoints

## Frontend — Registry pages

- Add searchable field dropdowns (Agreement Number, Debtor/Purchaser, Reg/Serial) for Collateral and HP
- Color-code View buttons (blue = active, orange = pending discharge/closure)
- Prefetch record detail on View click for faster edit mode
- Use `registryQueryOptions` and cache key bump to fix stale React Query data for client users
- Fix HP balance as read-only computed field in forms and view modals

## Frontend — View/Edit workflow

- View mode: Edit only
- Edit mode: Update (left) + Close (right, danger)
- Add shared `ConfirmDialog` for Update and Close/Discharge actions (replaces `window.confirm`)
- Make financier/debtor/purchaser fields read-only in edit mode
- Disable Data Date editing in create/edit forms
- Switch form validation to `onBlur`

## Frontend — Asset Registry fixes

- Add missing `Layers` icon import
- Add missing bulk-upload state (`fileInputRef`, `uploadFile`, `addMultipleOpen`) and upload modal
- Group Add Single / Add Multiple buttons in `flex gap-1` for consistent spacing

## Frontend — Sidebar / profile menu

- Portal profile dropdown to `document.body` with fixed positioning and higher z-index
- Restore correct collapsed-sidebar placement (opens to the right, bottom-aligned)
- Style Logout as red with pointer cursor on hover

## Test plan

- [x] Log in as staff and client user; verify Collateral/HP tables match dashboard stats
- [x] Confirm closed HP and discharged Collateral records do not appear in list views
- [x] Open View → Edit on Collateral and HP; verify read-only party fields and disabled Data Date
- [x] Test Update and Close flows; confirm app-styled dialogs appear and actions complete
- [x] Collapse sidebar; open profile menu and confirm it appears above registry tabs/page content
- [x] Open Asset Registry; verify page loads, Add Multiple works, and button spacing matches other registries
- [ ] Hard refresh after deploy to clear any stale localStorage React Query cache